### PR TITLE
add @fullstory/babel-plugin-annotate-react as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ yarn add @fullstory/react-native
 ## Configuring the babel plugin
 `@fullstory/babel-plugin-react-native` is automatically included as a dependency to the FullStory React Native plugin. Please refer to the babel plugin's [README.md](https://github.com/fullstorydev/fullstory-babel-plugin-react-native/blob/master/README.md) for information on how to configure it.
 
+`@fullstory/babel-plugin-annotate-react` is automatically included as a dependency to the FullStory React Native plugin. Please refer to the babel plugin's [README.md](https://github.com/fullstorydev/fullstory-babel-plugin-annotate-react/blob/master/README.md) for information on how to configure it for React Native.
+
 ## Importing the React Native plugin
 
 In order to use the FullStory Native Mobile SDK from within a React Native app, importing the React Native plugin is all that is required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,9 +54,9 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "regenerator-runtime": {
       "version": "0.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-zJgwVKvCBmaCsUWpv0QTK8ROGKaAslxnDjGgVwem8UDuxZYI9DFbwiZAjuYjmjXeLb+pSseGcX7TpjNWXjtybQ=="
     },
     "@fullstory/babel-plugin-react-native": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-0.9.3.tgz",
-      "integrity": "sha512-DO/0hcV2V8eBbg7biGDTz55ZNDAtHXab64XTE24vP9FOfeBqRgjxzDZWqncj/Lcezkf6h73ZZgcntp6M5u1rDA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-0.9.4.tgz",
+      "integrity": "sha512-gPZm/9lgh80cXtm6JAap1qLA83ZZtu1xdVxTIgXmGsJPtx8mKa4Wp5h56Erib75DwLKr1gYAf+NqXGqCaoBLuw==",
       "requires": {
         "babel-types": "^6.26.0",
         "babylon": "^6.18.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-zJgwVKvCBmaCsUWpv0QTK8ROGKaAslxnDjGgVwem8UDuxZYI9DFbwiZAjuYjmjXeLb+pSseGcX7TpjNWXjtybQ=="
     },
     "@fullstory/babel-plugin-react-native": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-0.9.2.tgz",
-      "integrity": "sha512-hy8kAfTTmCQm9U/QkPg2cSJimbHGSubQQJG7ZiQVPBvi3Hy/EOn3rS1PVrqLmOv6eJr3++1JehJgowPsv3hPnA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-0.9.3.tgz",
+      "integrity": "sha512-DO/0hcV2V8eBbg7biGDTz55ZNDAtHXab64XTE24vP9FOfeBqRgjxzDZWqncj/Lcezkf6h73ZZgcntp6M5u1rDA==",
       "requires": {
         "babel-types": "^6.26.0",
         "babylon": "^6.18.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@fullstory/babel-plugin-annotate-react": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-annotate-react/-/babel-plugin-annotate-react-1.0.2.tgz",
+      "integrity": "sha512-zJgwVKvCBmaCsUWpv0QTK8ROGKaAslxnDjGgVwem8UDuxZYI9DFbwiZAjuYjmjXeLb+pSseGcX7TpjNWXjtybQ=="
+    },
     "@fullstory/babel-plugin-react-native": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-0.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@fullstory/babel-plugin-annotate-react": "^1.0.2",
-    "@fullstory/babel-plugin-react-native": "^0.9.2"
+    "@fullstory/babel-plugin-react-native": "^0.9.3"
   },
   "peerDependencies": {
     "react": "*",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@fullstory/babel-plugin-annotate-react": "^1.0.2",
-    "@fullstory/babel-plugin-react-native": "^0.9.3"
+    "@fullstory/babel-plugin-react-native": "^0.9.4"
   },
   "peerDependencies": {
     "react": "*",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "fullstory"
   ],
   "dependencies": {
+    "@fullstory/babel-plugin-annotate-react": "^1.0.2",
     "@fullstory/babel-plugin-react-native": "^0.9.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
This is the initial change to make `@fullstory/babel-plugin-annotate-react` a dep for our RN plugin.

We will need a FS plugin update to take advantage of this, so no need to create a new tag for this release just yet.