### PR TITLE
Add `onReady` and move the NativeProps handlers to this plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ FullStory.getCurrentSessionURL().then(function(result) {
 ### Using the `fsAttribute` property
 Instead of setting attributes via an FS API method, use the `fsAttribute` property that FullStory's babel plugin adds to every React Native `View`.
 
-More information can be found [here](https://help.fullstory.com/hc/en-us/articles/360043356573-FullStory-for-Mobile-Apps-Privacy-Rules#fs-setattribute).
-
 ```JavaScript
 <Text fsAttribute={{custom_attr1: 'custom_value1', custom_attr2: 'custom_value2'}}>Text element with custom attributes</Text>
 ```
@@ -93,8 +91,6 @@ The 6 built-in `fsClass` string values are:
 * "fs-mask-without-consent"
 * "fs-unmask"
 * "fs-unmask-with-consent"
-
-More information can be found in the table at the end of [this section](https://help.fullstory.com/hc/en-us/articles/360043356573-FullStory-for-Mobile-Apps-Privacy-Rules#fs-setattribute).
 
 ```JavaScript
 <Text fsClass="fs-unmask">Text element that is unmasked</Text>

--- a/README.md
+++ b/README.md
@@ -56,10 +56,53 @@ FullStory.event('Subscribed', {
 });
 ```
 
+### Getting a callback once a session is created
+
+```JavaScript
+FullStory.onReady().then(function(result) {
+    const replayStartUrl = result.replayStartUrl;
+    const replayNowUrl = result.replayNowUrl;
+    const sessionId = result.sessionId;
+  });
+```
+
 ### Generating a session replay link
 
 ```JavaScript
 FullStory.getCurrentSessionURL().then(function(result) {
   const startOfPlayback = result;
 });
+```
+
+### Using the `fsAttribute` property
+Instead of setting attributes via an FS API method, use the `fsAttribute` property that FullStory's babel plugin adds to every React Native `View`.
+
+More information can be found [here](https://help.fullstory.com/hc/en-us/articles/360043356573-FullStory-for-Mobile-Apps-Privacy-Rules#fs-setattribute).
+
+```JavaScript
+<Text fsAttribute={{custom_attr1: 'custom_value1', custom_attr2: 'custom_value2'}}>Text element with custom attributes</Text>
+```
+
+### Using the `fsClass` property
+Instead of adding and removing classes via an FS API method, use the `fsClass` property that FullStory's babel plugin adds to every React Native `View`.
+
+The 6 built-in `fsClass` string values are:
+* "fs-exclude"
+* "fs-exclude-without-consent"
+* "fs-mask"
+* "fs-mask-without-consent"
+* "fs-unmask"
+* "fs-unmask-with-consent"
+
+More information can be found in the table at the end of [this section](https://help.fullstory.com/hc/en-us/articles/360043356573-FullStory-for-Mobile-Apps-Privacy-Rules#fs-setattribute).
+
+```JavaScript
+<Text fsClass="fs-unmask">Text element that is unmasked</Text>
+```
+
+### Using the `fsTagName` property
+Instead of setting the tag name via an FS API method, use the `fsTagName` property that FullStory's babel plugin adds to every React Native `View`.
+
+```JavaScript
+<Text fsTagName="custom-tag-name">Text element with a custom tag name</Text>
 ```

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
@@ -2,15 +2,20 @@
 package com.fullstory.reactnative;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
 
 import com.fullstory.FS;
+import com.fullstory.FSOnReadyListener;
+import com.fullstory.FSSessionData;
 
 public class FullStoryModule extends ReactContextBaseJavaModule {
 
@@ -41,6 +46,42 @@ public class FullStoryModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public static void setUserVars(ReadableMap userVars) {
         FS.setUserVars(toMap(userVars));
+    }
+
+    @ReactMethod
+    public static void onReady(Promise promise) {
+        if (promise == null) {
+            return;
+        }
+
+        // we can only invoke the promise callback once, so create an AtomicReference
+        // to handle the logic
+        final AtomicReference<Promise> promiseOneShot = new AtomicReference(promise);
+        FS.setReadyListener(new FSOnReadyListener() {
+            @Override
+            public void onReady(FSSessionData sessionData) {
+                // get the current value and set the new value to null
+                Promise promise = promiseOneShot.getAndSet(null);
+                if (promise == null) {
+                    // this was already run once, so ignore
+                    return;
+                }
+
+                WritableMap map = Arguments.createMap();
+
+                // add the replay start url
+                map.putString("replayStartUrl", sessionData.getCurrentSessionURL());
+
+                // add the replay now url
+                map.putString("replayNowUrl", FS.getCurrentSessionURL(true));
+
+                // add the session id
+                map.putString("sessionId", FS.getCurrentSession());
+
+                // now resolve the promise
+                promise.resolve(map);
+            }
+        });
     }
 
     @ReactMethod

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
@@ -1,21 +1,18 @@
-
 package com.fullstory.reactnative;
-
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
-
 import com.fullstory.FS;
 import com.fullstory.FSOnReadyListener;
 import com.fullstory.FSSessionData;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class FullStoryModule extends ReactContextBaseJavaModule {
 
@@ -124,6 +121,5 @@ public class FullStoryModule extends ReactContextBaseJavaModule {
         }
 
         return map.toHashMap();
-
     }
 }

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryNativeProps.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryNativeProps.java
@@ -1,26 +1,43 @@
 package com.fullstory.reactnative;
 
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.Map;
-
 import android.view.View;
 
 import com.facebook.react.bridge.ReadableMap;
-
 import com.fullstory.FS;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
 public class FullStoryNativeProps {
+    // Keeps a list of the attributes set on a given View, so we can clear out the attributes
+    // any time set_fsAttribute is called.
+    private static final WeakHashMap<View, List<String>> ATTR_LIST = new WeakHashMap<>();
+
     private FullStoryNativeProps() {
         // prevent instantiation
     }
 
-    @NativeProp(name="fsAttribute")
+    @NativeProp(name = "fsAttribute")
     public static void set_fsAttribute(View view, ReadableMap fsAttributes) {
+        // Always clear out the existing attributes first.
+        // Note that, since the dataComponent, dataElement, and dataSourceFile values are stores as
+        // attributes, we can't just clear out all existing attributes. Instead, we must keep track
+        // of all of the attributes that were set and remove them individually.
+        List<String> existingAttributes = ATTR_LIST.remove(view);
+        if (existingAttributes != null) {
+            for (String attr : existingAttributes) {
+                FS.removeAttribute(view, attr);
+            }
+        }
         if (fsAttributes == null) {
             return;
         }
 
+        List<String> newAttributes = new ArrayList<>();
         Iterator<Map.Entry<String, Object>> it = fsAttributes.getEntryIterator();
         while (it.hasNext()) {
             Map.Entry<String, Object> entry = it.next();
@@ -34,12 +51,20 @@ public class FullStoryNativeProps {
                 value = obj.toString();
             }
 
-            FS.setAttribute(view, entry.getKey(), value);
+            String key = entry.getKey();
+            newAttributes.add(key);
+            FS.setAttribute(view, key, value);
         }
+
+        // Store the new list of attributes.
+        ATTR_LIST.put(view, newAttributes);
     }
 
-    @NativeProp(name="fsClass")
+    @NativeProp(name = "fsClass")
     public static void set_fsClass(View view, String fsClass) {
+        // always clear out the existing classes first
+        FS.removeAllClasses(view);
+
         if (fsClass == null) {
             // nothing to do
             return;
@@ -59,22 +84,22 @@ public class FullStoryNativeProps {
         }
     }
 
-    @NativeProp(name="fsTagName")
+    @NativeProp(name = "fsTagName")
     public static void set_fsTagName(View view, String fsTagName) {
         FS.setTagName(view, fsTagName);
     }
 
-    @NativeProp(name="dataComponent")
+    @NativeProp(name = "dataComponent")
     public static void set_dataComponent(View view, String value) {
         setElementIdentity(view, "data-component", value);
     }
 
-    @NativeProp(name="dataElement")
+    @NativeProp(name = "dataElement")
     public static void set_dataElement(View view, String value) {
         setElementIdentity(view, "data-element", value);
     }
 
-    @NativeProp(name="dataSourceFile")
+    @NativeProp(name = "dataSourceFile")
     public static void set_dataSourceFile(View view, String value) {
         setElementIdentity(view, "data-source-file", value);
     }

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryNativeProps.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryNativeProps.java
@@ -1,0 +1,123 @@
+package com.fullstory.reactnative;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+
+import android.view.View;
+
+import com.facebook.react.bridge.ReadableMap;
+
+import com.fullstory.FS;
+
+public class FullStoryNativeProps {
+    private FullStoryNativeProps() {
+        // prevent instantiation
+    }
+
+    public static void set_fsAttribute(View view, ReadableMap fsAttributes) {
+        // TODO: remove any attributes that were previously added
+
+        if (fsAttributes == null) {
+            return;
+        }
+
+        Iterator<Map.Entry<String, Object>> it = fsAttributes.getEntryIterator();
+        while (it.hasNext()) {
+            Map.Entry<String, Object> entry = it.next();
+
+            Object obj = entry.getValue();
+
+            String value;
+            if (obj == null || obj instanceof String) {
+                value = (String) obj;
+            } else {
+                value = obj.toString();
+            }
+
+            FS.setAttribute(view, entry.getKey(), value);
+        }
+    }
+
+    public static void set_fsClass(View view, String fsClass) {
+        // TODO: remove any classes that were previously added
+
+        if (fsClass == null) {
+            // nothing to do
+            return;
+        }
+
+        String[] splits = fsClass.split(",");
+        int length = splits.length;
+        if (length == 0) {
+            // nothing to do
+            return;
+        }
+
+        if (length == 1) {
+            FS.addClass(view, splits[0]);
+        } else {
+            FS.addClasses(view, Arrays.asList(splits));
+        }
+    }
+
+    public static void set_fsTagName(View view, String fsTagName) {
+        FS.setTagName(view, fsTagName);
+    }
+
+    public static void set_dataComponent(View view, String value) {
+        setElementIdentity(view, "data-component", value);
+    }
+
+    public static void set_dataElement(View view, String value) {
+        setElementIdentity(view, "data-element", value);
+    }
+
+    public static void set_dataSourceFile(View view, String value) {
+        setElementIdentity(view, "data-source-file", value);
+    }
+
+    public static void setProperty(View view, String propName, Object value) {
+        switch (propName) {
+            case "fsAttribute":
+                if (value == null || value instanceof ReadableMap) {
+                    set_fsAttribute(view, (ReadableMap) value);
+                }
+                break;
+            case "fsClass":
+                if (value == null || value instanceof String) {
+                    set_fsClass(view, (String) value);
+                }
+                break;
+            case "fsTagName":
+                if (value == null || value instanceof String) {
+                    set_fsTagName(view, (String) value);
+                }
+                break;
+            case "dataComponent":
+                if (value == null || value instanceof String) {
+                    set_dataComponent(view, (String) value);
+                }
+                break;
+            case "dataElement":
+                if (value == null || value instanceof String) {
+                    set_dataElement(view, (String) value);
+                }
+                break;
+            case "dataSourceFile":
+                if (value == null || value instanceof String) {
+                    set_dataSourceFile(view, (String) value);
+                }
+                break;
+        }
+    }
+
+    private static void setElementIdentity(View view, String key, String value) {
+        if (value == null) {
+            FS.removeAttribute(view, key);
+            return;
+        }
+
+        FS.setAttribute(view, key, value);
+    }
+}

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryNativeProps.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryNativeProps.java
@@ -17,8 +17,6 @@ public class FullStoryNativeProps {
 
     @NativeProp(name="fsAttribute")
     public static void set_fsAttribute(View view, ReadableMap fsAttributes) {
-        // TODO: remove any attributes that were previously added
-
         if (fsAttributes == null) {
             return;
         }
@@ -42,8 +40,6 @@ public class FullStoryNativeProps {
 
     @NativeProp(name="fsClass")
     public static void set_fsClass(View view, String fsClass) {
-        // TODO: remove any classes that were previously added
-
         if (fsClass == null) {
             // nothing to do
             return;

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryNativeProps.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryNativeProps.java
@@ -15,6 +15,7 @@ public class FullStoryNativeProps {
         // prevent instantiation
     }
 
+    @NativeProp(name="fsAttribute")
     public static void set_fsAttribute(View view, ReadableMap fsAttributes) {
         // TODO: remove any attributes that were previously added
 
@@ -39,6 +40,7 @@ public class FullStoryNativeProps {
         }
     }
 
+    @NativeProp(name="fsClass")
     public static void set_fsClass(View view, String fsClass) {
         // TODO: remove any classes that were previously added
 
@@ -61,18 +63,22 @@ public class FullStoryNativeProps {
         }
     }
 
+    @NativeProp(name="fsTagName")
     public static void set_fsTagName(View view, String fsTagName) {
         FS.setTagName(view, fsTagName);
     }
 
+    @NativeProp(name="dataComponent")
     public static void set_dataComponent(View view, String value) {
         setElementIdentity(view, "data-component", value);
     }
 
+    @NativeProp(name="dataElement")
     public static void set_dataElement(View view, String value) {
         setElementIdentity(view, "data-element", value);
     }
 
+    @NativeProp(name="dataSourceFile")
     public static void set_dataSourceFile(View view, String value) {
         setElementIdentity(view, "data-source-file", value);
     }

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryPackage.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryPackage.java
@@ -1,23 +1,22 @@
-
 package com.fullstory.reactnative;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
-import com.facebook.react.bridge.JavaScriptModule;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 public class FullStoryPackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-      return Arrays.<NativeModule>asList(new FullStoryModule(reactContext));
+        return Arrays.<NativeModule>asList(new FullStoryModule(reactContext));
     }
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-      return Collections.emptyList();
+        return Collections.emptyList();
     }
 }

--- a/android/src/main/java/com/fullstory/reactnative/NativeProp.java
+++ b/android/src/main/java/com/fullstory/reactnative/NativeProp.java
@@ -1,0 +1,16 @@
+package com.fullstory.reactnative;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(ElementType.METHOD)
+public @interface NativeProp {
+ /**
+   * Name of the property exposed to JS
+   */
+  String name();
+}

--- a/android/src/main/java/com/fullstory/reactnative/NativeProp.java
+++ b/android/src/main/java/com/fullstory/reactnative/NativeProp.java
@@ -1,16 +1,16 @@
 package com.fullstory.reactnative;
 
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 @Retention(RUNTIME)
 @Target(ElementType.METHOD)
 public @interface NativeProp {
- /**
-   * Name of the property exposed to JS
-   */
-  String name();
+    /**
+     * Name of the property exposed to JS
+     */
+    String name();
 }

--- a/ios/FullStory.h
+++ b/ios/FullStory.h
@@ -1,6 +1,6 @@
 #import <React/RCTBridgeModule.h>
 #import <FullStory/FS.h>
 
-@interface FullStory : NSObject <RCTBridgeModule>
+@interface FullStory : NSObject <RCTBridgeModule, FSDelegate>
 
 @end

--- a/ios/FullStory.h
+++ b/ios/FullStory.h
@@ -1,5 +1,6 @@
 #import <React/RCTBridgeModule.h>
 #import <FullStory/FS.h>
+#import <FullStory/FSDelegate.h>
 
 @interface FullStory : NSObject <RCTBridgeModule, FSDelegate>
 

--- a/ios/FullStory.m
+++ b/ios/FullStory.m
@@ -1,5 +1,9 @@
 #import "FullStory.h"
 
+#import <objc/runtime.h>
+
+#import <React/RCTView.h>
+#import <React/RCTViewManager.h>
 
 @implementation FullStory {
 	RCTPromiseResolveBlock onReadyPromise;
@@ -93,6 +97,82 @@ RCT_REMAP_METHOD(onReady, onReadyWithResolver:(RCTPromiseResolveBlock)resolve re
 		 * immediately. */
 		[self fullstoryDidStartSession:FS.currentSessionURL];
 	}
+}
+
+@end
+
+static const char *_rctview_previous_attributes_key = "associated_object_rctview_previous_attributes_key";
+
+@implementation RCTViewManager (FullStory)
+
++ (NSArray<NSString *> *) propConfig_fsClass {
+	return @[@"NSString *", @"__custom__"];
+}
+
+- (void) set_fsClass:(id)json forView:(RCTView*)view withDefaultView:(RCTView *)defaultView {
+	NSArray <NSString *>* classes = [(NSString *)json componentsSeparatedByString: @","];
+	[FS removeAllClasses:view];
+	[FS addClasses:view classNames:classes];
+}
+
++ (NSArray<NSString *> *) propConfig_dataComponent {
+	return @[@"NSString *", @"__custom__"];
+}
+
+- (void) set_dataComponent:(id)json forView:(RCTView*)view withDefaultView:(RCTView *)defaultView {
+	[FS setAttribute:view attributeName:@"data-component" attributeValue:(NSString *)json];
+}
+
++ (NSArray<NSString *> *) propConfig_dataElement {
+	return @[@"NSString *", @"__custom__"];
+}
+
+- (void) set_dataElement:(id)json forView:(RCTView*)view withDefaultView:(RCTView *)defaultView {
+	[FS setAttribute:view attributeName:@"data-element" attributeValue:(NSString *)json];
+}
+
++ (NSArray<NSString *> *) propConfig_dataSourceFile {
+	return @[@"NSString *", @"__custom__"];
+}
+
+- (void) set_dataSourceFile:(id)json forView:(RCTView*)view withDefaultView:(RCTView *)defaultView {
+	[FS setAttribute:view attributeName:@"data-source-file" attributeValue:(NSString *)json];
+}
+
++ (NSArray<NSString *> *) propConfig_fsTagName {
+	return @[@"NSString *", @"__custom__"];
+}
+
+- (void) set_fsTagName:(id)json forView:(RCTView*)view withDefaultView:(RCTView *)defaultView {
+	[FS setTagName:view tagName:(NSString *)json];
+}
+
++ (NSArray<NSString *> *) propConfig_fsAttribute {
+	return @[@"NSDictionary *", @"__custom__"];
+}
+
+- (void) set_fsAttribute:(id)json forView:(RCTView*)view withDefaultView:(RCTView *)defaultView {
+	NSDictionary *newAttrs = (NSDictionary *)json;
+	
+	/* Clear up all the old attributes first, if they exist. */
+	NSSet *oldAttrs = objc_getAssociatedObject(view, _rctview_previous_attributes_key);
+	if (oldAttrs) {
+		for (NSString *attr in oldAttrs) {
+			[FS removeAttribute:view attributeName:attr];
+		}
+	}
+	
+	/* Load in the new attributes. */
+	NSMutableSet *newAttrSet = [NSMutableSet new];
+	if (newAttrs) {
+		for (NSString *attr in newAttrs) {
+			[FS setAttribute:view attributeName:attr attributeValue:(NSString *)newAttrs[attr]];
+			[newAttrSet addObject:attr];
+		}
+	}
+	
+	/* And set them up for cleanup next time. */
+	objc_setAssociatedObject(view, _rctview_previous_attributes_key, newAttrSet, OBJC_ASSOCIATION_RETAIN);
 }
 
 @end


### PR DESCRIPTION
In conjunction with the upcoming FS `1.5.5` release, we are moving the NativeProps receivers to this plugin and out from the FS plugin.

Additionally, this PR adds the FS.onReady API.