### PR TITLE
Resolve UniModules incompatibility by swizzling [RCTComponentData viewConfig].

### DIFF
--- a/ios/FSReactSwizzle.h
+++ b/ios/FSReactSwizzle.h
@@ -1,0 +1,50 @@
+#import <Foundation/Foundation.h>
+
+#define __DO_SWIZZLE_BLOCK(ARGS...) \
+    block = ^(id self, ##ARGS)
+
+#define __DO_SWIZZLE(SEL) { \
+    /* convert block to IMP trampoline and replace method implementation */ \
+    IMP imp = imp_implementationWithBlock(block); \
+    \
+    /* Try adding the method if not yet in the current class */ \
+    if (!class_addMethod(c, SEL, imp, method_getTypeEncoding(m))) { \
+        orig = (OrigFnPtr)method_setImplementation(m, imp); \
+    } else { \
+        orig = (OrigFnPtr)method_getImplementation(m); \
+    } \
+} \
+
+#define __DO_METHOD_PTR(RETURN_VALUE, ARGS...) \
+    typedef RETURN_VALUE (*OrigFnPtr)(id, SEL, ##ARGS); \
+    __block OrigFnPtr orig; \
+
+#define __SWIZZLE_BEGIN(IS_CLASS, CLASS, SELECTOR, RETURN_TYPE, ARGS...) do { \
+    /* Front-load some operations */ \
+    Class c = objc_getClass(#CLASS); \
+    if (!c) { NSLog(@"FS: did not get class " #CLASS); break; } \
+    __attribute__((unused)) SEL sel = SELECTOR; \
+    RETURN_TYPE(^block)(id, ##ARGS) = nil;\
+    Method m = IS_CLASS ? class_getClassMethod(c, SELECTOR) : class_getInstanceMethod(c, SELECTOR); \
+    if (IS_CLASS) c = object_getClass(c); \
+    __DO_METHOD_PTR(RETURN_TYPE, ##ARGS) \
+    \
+    for (int i = 0; i < 2; i++) { \
+    switch (i) { \
+        case 1: \
+        __DO_SWIZZLE(SELECTOR); \
+        break; \
+        case 0: \
+        __DO_SWIZZLE_BLOCK(ARGS)
+
+#define SWIZZLE_END ; } } } while(0);
+
+#define SWIZZLE_BEGIN_INSTANCE(CLASS, SELECTOR, RETURN_TYPE, ARGS...) \
+    __SWIZZLE_BEGIN(false, CLASS, SELECTOR, RETURN_TYPE, ##ARGS)
+
+#define SWIZZLE_BEGIN_CLASS(CLASS, SELECTOR, RETURN_TYPE, ARGS...) \
+    __SWIZZLE_BEGIN(true, CLASS, SELECTOR, RETURN_TYPE, ##ARGS)
+
+#define SWIZZLED_METHOD(ARGS...) \
+    orig(self, sel, ##ARGS)
+

--- a/ios/FullStory.m
+++ b/ios/FullStory.m
@@ -4,6 +4,9 @@
 
 #import <React/RCTView.h>
 #import <React/RCTViewManager.h>
+#import <React/RCTComponentData.h>
+
+#import "FSReactSwizzle.h"
 
 @implementation FullStory {
 	RCTPromiseResolveBlock onReadyPromise;
@@ -175,4 +178,27 @@ static const char *_rctview_previous_attributes_key = "associated_object_rctview
 	objc_setAssociatedObject(view, _rctview_previous_attributes_key, newAttrSet, OBJC_ASSOCIATION_RETAIN);
 }
 
+@end
+
+@interface FSReactSwizzleBootstrap : NSObject
+@end
+
+@implementation FSReactSwizzleBootstrap
++ (void) load {
+	/* class_copyMethodList in RCTComponentData's lookup of NativeProps
+	 * can't see the propConfigs that we create in the superclass.  So
+	 * we swizzle that to inject our NativeProps directly in there, so
+	 * UniModules knows to pass them through.
+	 */
+	SWIZZLE_BEGIN_INSTANCE(RCTComponentData, @selector(viewConfig), NSDictionary *) {
+		NSDictionary<NSString *, id> *r = SWIZZLED_METHOD();
+		r[@"propTypes"][@"fsClass"] = @"NSString *";
+		r[@"propTypes"][@"dataComponent"] = @"NSString *";
+		r[@"propTypes"][@"dataElement"] = @"NSString *";
+		r[@"propTypes"][@"dataSourceFile"] = @"NSString *";
+		r[@"propTypes"][@"fsTagName"] = @"NSString *";
+		r[@"propTypes"][@"fsAttribute"] = @"NSDictionary *";
+		return r;
+	} SWIZZLE_END;
+}
 @end


### PR DESCRIPTION
UniModules gets confused about FullStory properties; it generates a list of
'proxiedProperties' that, in theory, excludes properties that come from React
Native.  Unfortunately, it doesn't see the FullStory properties, and takes
those out of the main tag, and passes them in the proxiedProperties struct to
the UniModule view.  This means that we don't get to see the property -- and
that UniModule generates an irritated warning about this.

We solve this by swizzling [RCTComponentData viewConfig] to inject the
FullStory properties into each view's list of NativeProps.  We need to do this
because NativeProps uses class_copyMethodList, which stops at the superclass
boundary -- therefore, it wouldn't see the methods that we added to
RCTViewManager in an @implementation.