### PR TITLE
Update React Native dependency declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.2
+
+Changed how the peer dependency for React Native is declared to better handle strict dependency checking
+
+## 1.0.1
+
+Link to a newer version of @fullstory/babel-plugin-annotate-react in order to fix React.Fragment and provide unimodules support 
+
 ## 1.0.0
 
 1.0.0 release!

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,9 +29,9 @@
       "integrity": "sha512-tJkoG5jdF1w7aWJjzce/daqWOI9rYqkNg6WaAiBMFEwspGEa104bd3o5L9kPfzMdy5gP5e56AWHHibuGWCBI9A=="
     },
     "@fullstory/babel-plugin-react-native": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.0.0.tgz",
-      "integrity": "sha512-gKi6A+fqaTGa9Ofi4jNczIEsEZrjGRyZZ++FKOQEzfHNEC+eY9SJQ2A3FzVeikyIDrdC88qvmMqAjz8pTd0n8A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.0.1.tgz",
+      "integrity": "sha512-N1FK2mZRnFXlEIhVkarVfS1akwTklIpPRyvfevMSqgl0pmCbeBPQPrrpecEDeURKh9X0OOQUWrrV0Mor5ZAAjA==",
       "requires": {
         "@babel/parser": "^7.0.0",
         "@babel/types": "^7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,29 +5,28 @@
   "requires": true,
   "dependencies": {
     "@babel/helper-validator-identifier": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
     },
     "@babel/parser": {
-      "version": "7.11.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
-      "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA=="
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
+      "integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q=="
     },
     "@babel/types": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-      "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       }
     },
     "@fullstory/babel-plugin-annotate-react": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-annotate-react/-/babel-plugin-annotate-react-2.0.0.tgz",
-      "integrity": "sha512-Trnot+3DYd4YicBLh0Ac0KcsA+WvlsQQCdGo+GgnVu13NHwlj7D6klZGAbGUbup7O0/ULF8iOq6+O/jZE+wXFQ=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-annotate-react/-/babel-plugin-annotate-react-2.1.2.tgz",
+      "integrity": "sha512-tJkoG5jdF1w7aWJjzce/daqWOI9rYqkNg6WaAiBMFEwspGEa104bd3o5L9kPfzMdy5gP5e56AWHHibuGWCBI9A=="
     },
     "@fullstory/babel-plugin-react-native": {
       "version": "1.0.0",
@@ -37,11 +36,6 @@
         "@babel/parser": "^7.0.0",
         "@babel/types": "^7.0.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "fullstory"
   ],
   "dependencies": {
-    "@fullstory/babel-plugin-annotate-react": "^2.0.0",
-    "@fullstory/babel-plugin-react-native": "^1.0.0"
+    "@fullstory/babel-plugin-annotate-react": ">=2.0.0",
+    "@fullstory/babel-plugin-react-native": ">=1.0.0"
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "^0.61.0"
+    "react-native": ">=0.61.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "fullstory"
   ],
   "dependencies": {
-    "@fullstory/babel-plugin-annotate-react": ">=2.0.0",
-    "@fullstory/babel-plugin-react-native": ">=1.0.0"
+    "@fullstory/babel-plugin-annotate-react": "^2.0.0",
+    "@fullstory/babel-plugin-react-native": "^1.0.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "The official FullStory React Native plugin",
   "repository": "git://github.com/fullstorydev/fullstory-react-native.git",
   "homepage": "https://github.com/fullstorydev/fullstory-react-native",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The official FullStory React Native plugin",
   "repository": "git://github.com/fullstorydev/fullstory-react-native.git",
   "homepage": "https://github.com/fullstorydev/fullstory-react-native",


### PR DESCRIPTION
Using `^` breaks the newest version of `npm`, which will strictly check for peer dependencies. This change addresses that by using `>=`.