### PR TITLE
add the ability to invoke FS.log via javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+
+Added the ability to invoke the `log` API from within React Native. See more information [here](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-FullStory-React-Native-Recording#01FM34C43RGW28NMC8PDWC7EZB)
+
 ## 1.0.2
 
 Changed how the peer dependency for React Native is declared to better handle strict dependency checking

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
@@ -115,6 +115,43 @@ public class FullStoryModule extends ReactContextBaseJavaModule {
         FS.restart();
     }
 
+    @ReactMethod
+    public static void log(double level, String message) {
+        // Convert the double to an int
+        int intLevel = Double.valueOf(level).intValue();
+        // React Native LogLevels:
+        // Log    = 0, // Clamps to Debug on iOS
+        // Debug  = 1,
+        // Info   = 2, // Default
+        // Warn   = 3,
+        // Error  = 4,
+        // Assert = 5, // Clamps to Error on Android
+        FS.LogLevel actualLevel;
+        switch (intLevel) {
+            case 0:
+                actualLevel = FS.LogLevel.LOG;
+                break;
+            case 1:
+                actualLevel = FS.LogLevel.DEBUG;
+                break;
+            case 3:
+                actualLevel = FS.LogLevel.WARN;
+                break;
+            case 4:
+            case 5:
+                actualLevel = FS.LogLevel.ERROR;
+                break;
+            case 2:
+            default:
+                // default to INFO
+                actualLevel = FS.LogLevel.INFO;
+            break;
+        }
+
+        // Call through to FS.log with the enum
+        FS.log(actualLevel, message);
+    }
+
     private static Map toMap(ReadableMap map) {
         if (map == null) {
             return null;

--- a/ios/FullStory.m
+++ b/ios/FullStory.m
@@ -86,29 +86,27 @@ RCT_EXPORT_METHOD(log:(nonnull NSNumber *)level message:(NSString *)message)
 	// Warn   = 3,
 	// Error  = 4,
 	// Assert = 5, // Clamps to Error on Android
-	NSNumber *levelNumber;
+	FSEventLogLevel levelValue;
 	switch (level.intValue) {
 		case 0:
 		case 1:
-			levelNumber = @(FSLOG_DEBUG);
+			levelValue = FSLOG_DEBUG;
 			break;
 		case 3:
-			levelNumber = @(FSLOG_WARNING);
+			levelValue = FSLOG_WARNING;
 			break;
 		case 4:
-			levelNumber = @(FSLOG_ERROR);
+			levelValue = FSLOG_ERROR;
 			break;
 		case 5:
-			levelNumber = @(FSLOG_ASSERT);
+			levelValue = FSLOG_ASSERT;
 			break;
 		case 2:
 		default:
 			// default to INFO
-			levelNumber = @(FSLOG_INFO);
+			levelValue = FSLOG_INFO;
 		break;
 	}
-
-	FSEventLogLevel levelValue = (FSEventLogLevel)levelNumber.unsignedCharValue;
 
 	dispatch_async(dispatch_get_main_queue(), ^{
 		[FS logWithLevel:levelValue message:message];

--- a/ios/FullStory.m
+++ b/ios/FullStory.m
@@ -77,6 +77,44 @@ RCT_EXPORT_METHOD(restart)
 	});
 }
 
+RCT_EXPORT_METHOD(log:(nonnull NSNumber *)level message:(NSString *)message)
+{
+	// React Native LogLevels:
+	// Log    = 0, // Clamps to Debug on iOS
+	// Debug  = 1,
+	// Info   = 2, // Default
+	// Warn   = 3,
+	// Error  = 4,
+	// Assert = 5, // Clamps to Error on Android
+	NSNumber *levelNumber;
+	switch (level.intValue) {
+		case 0:
+		case 1:
+			levelNumber = @(FSLOG_DEBUG);
+			break;
+		case 3:
+			levelNumber = @(FSLOG_WARNING);
+			break;
+		case 4:
+			levelNumber = @(FSLOG_ERROR);
+			break;
+		case 5:
+			levelNumber = @(FSLOG_ASSERT);
+			break;
+		case 2:
+		default:
+			// default to INFO
+			levelNumber = @(FSLOG_INFO);
+		break;
+	}
+
+	FSEventLogLevel levelValue = (FSEventLogLevel)levelNumber.unsignedCharValue;
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[FS logWithLevel:levelValue message:message];
+	});
+}
+
 - (void) fullstoryDidStartSession:(NSString *)sessionUrl {
 	if (!onReadyPromise)
 		return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "The official FullStory React Native plugin",
   "repository": "git://github.com/fullstorydev/fullstory-react-native.git",
   "homepage": "https://github.com/fullstorydev/fullstory-react-native",

--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,15 @@ import { NativeModules } from 'react-native';
 
 const { FullStory } = NativeModules;
 
+const LogLevel = {
+    Log: 0, // Clamps to Debug on iOS
+    Debug: 1,
+    Info: 2, // Default
+    Warn: 3,
+    Error: 4,
+    Assert: 5, // Clamps to Error on Android
+}
+
+FullStory.LogLevel = LogLevel;
+
 export default FullStory;


### PR DESCRIPTION
This PR exposes the FS.log infrastructure to React Native Javascript.

The log method takes an int enum and will default to `Info` if the int is invalid.

Usage:
```
import FullStory from '@fullstory/react-native';

// Exercise the logging
FullStory.log(FullStory.LogLevel.Log, 'Log at Log (on iOS, clamps to Debug)');
FullStory.log(FullStory.LogLevel.Debug, 'Log at Debug');
FullStory.log(FullStory.LogLevel.Info, 'Log at Info');
FullStory.log(FullStory.LogLevel.Warn, 'Log at Warn');
FullStory.log(FullStory.LogLevel.Error, 'Log at Error');
FullStory.log(FullStory.LogLevel.Assert, 'Log at Assert (on Android, clamps to Error)');
FullStory.log(-1, 'Log at -1 (defaults to Info)');
FullStory.log(10, 'Log at 10 (defaults to Info)');
```