### PR TITLE
Adds type declarations

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,21 @@
+interface UserVars {
+    displayName?: string;
+    email?: string;
+    [key: string]: any;
+}
+
+// API functions that are available as soon as the snippet has executed.
+export function anonymize(): void;
+export function consent(userConsents?: boolean): void;
+export function event(eventName: string, eventProperties: { [key: string]: any }): void;
+export function identify(uid: string, customVars?: UserVars): void;
+export function restart(): void;
+export function setUserVars(customVars: UserVars): void;
+export function shutdown(): void;
+export function setUserVars(vars: UserVars): void;
+// API functions that are available after /rec/page returns.
+// FullStory bootstrapping details: https://help.fullstory.com/hc/en-us/articles/360032975773
+export function getCurrentSessionURL(now?: boolean): string | null;
+export function getCurrentSession(): string | null;
+
+export function onReady(): void;


### PR DESCRIPTION
This PR adds type declaration to the package.
Most of these types are copied from the browser SDK https://github.com/fullstorydev/fullstory-browser-sdk/blob/main/src/index.d.ts

I'm not 100% sure if all them are exactly correct, I took an educated guess based on the Android Native module definition and [docs](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-FullStory-React-Native-Capture#01ER0FBDD02AS5FXJ0M3076D5R) for `setUserVars` and `getCurrentSession`. Happy to make any changes if these are not completely solid.