### PR TITLE
add our base attributes to the global namespace

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,4 +32,14 @@ interface FullStoryInterface {
   log(number, string): void;
 }
 
+declare global {
+  namespace JSX {
+    interface IntrinsicAttributes {
+      fsAttribute?: {[key: string]: string};
+      fsClass?: string;
+      fsTagName?: string;
+    }
+  }
+}
+
 export default FullStory as FullStoryInterface;


### PR DESCRIPTION
This PR auto-adds our base attributes to the global TS namespace, so our users won't have to do it manually.