### PR TITLE
release 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.5
+Updated the minimum version for the FullStory `@fullstory/babel-plugin-react-native` babel plugin to 1.0.2, to better work around metro server issues.
+
 ## 1.0.4
 Updated the minimum versions for the FullStory babel plugins. Added a Typescript declaration for the FullStory base attributes. Added Typescript declarations for the FullStory API.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/react-native",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "^2.2.0",
-        "@fullstory/babel-plugin-react-native": "^1.0.1"
+        "@fullstory/babel-plugin-react-native": "^1.0.2"
       },
       "peerDependencies": {
         "react": "*",
@@ -1976,9 +1976,9 @@
       "integrity": "sha512-HNgrDquQtDKowk86z7oOyXlAk1YmhCpIFNiTfkaKyCZnV6ceYo+ynFpd9kBwIPZ99DbIl8XnNHDSaK+aw1zAJQ=="
     },
     "node_modules/@fullstory/babel-plugin-react-native": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.0.1.tgz",
-      "integrity": "sha512-N1FK2mZRnFXlEIhVkarVfS1akwTklIpPRyvfevMSqgl0pmCbeBPQPrrpecEDeURKh9X0OOQUWrrV0Mor5ZAAjA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.0.2.tgz",
+      "integrity": "sha512-smJZGUdfbI4TOZW0euIsOgsEt5MNUZYAMeS63NJAkzePk7BW57H1vTOCftCJSxh5vh4FCtzK5+DCZQ6xKLkRmw==",
       "dependencies": {
         "@babel/parser": "^7.0.0",
         "@babel/types": "^7.0.0"
@@ -9747,9 +9747,9 @@
       "integrity": "sha512-HNgrDquQtDKowk86z7oOyXlAk1YmhCpIFNiTfkaKyCZnV6ceYo+ynFpd9kBwIPZ99DbIl8XnNHDSaK+aw1zAJQ=="
     },
     "@fullstory/babel-plugin-react-native": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.0.1.tgz",
-      "integrity": "sha512-N1FK2mZRnFXlEIhVkarVfS1akwTklIpPRyvfevMSqgl0pmCbeBPQPrrpecEDeURKh9X0OOQUWrrV0Mor5ZAAjA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.0.2.tgz",
+      "integrity": "sha512-smJZGUdfbI4TOZW0euIsOgsEt5MNUZYAMeS63NJAkzePk7BW57H1vTOCftCJSxh5vh4FCtzK5+DCZQ6xKLkRmw==",
       "requires": {
         "@babel/parser": "^7.0.0",
         "@babel/types": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@fullstory/babel-plugin-annotate-react": "^2.2.0",
-    "@fullstory/babel-plugin-react-native": "^1.0.1"
+    "@fullstory/babel-plugin-react-native": "^1.0.2"
   },
   "peerDependencies": {
     "react": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "The official FullStory React Native plugin",
   "repository": "git://github.com/fullstorydev/fullstory-react-native.git",
   "homepage": "https://github.com/fullstorydev/fullstory-react-native",


### PR DESCRIPTION
This PR releases 1.0.5, which just updated our `@fullstory/babel-plugin-react-native` minimum to 1.0.2.