### PR TITLE
add resetIdleTimer to the typescript definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.7
+Added `FS.resetIdleTimer` to the TypeScript types.
+
 ## 1.0.6
 Added support for calling `FS.resetIdleTimer`. This release now requires a minimum FullStory plugin version of `1.14.0`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/react-native",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "The official FullStory React Native plugin",
   "repository": "git://github.com/fullstorydev/fullstory-react-native.git",
   "homepage": "https://github.com/fullstorydev/fullstory-react-native",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,6 +30,7 @@ interface FullStoryInterface {
   shutdown(): void;
   restart(): void;
   log(number, string): void;
+  resetIdleTimer(): void;
 }
 
 declare global {


### PR DESCRIPTION
This PR adds resetIdleTimer to the typescript type definitions. I will use this PR as a 1.0.7 release PR once this is approved.