### PR TITLE
Fixing Typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "FullStory",
   "license": "MIT",
   "main": "src/index.js",
-  "types": "src/index.d.js",
+  "types": "src/index.d.ts",
   "files": [
     "android",
     "ios",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,46 +1,56 @@
-import {NativeModules} from 'react-native';
-
-declare const {FullStory} = NativeModules;
-
 export type OnReadyResponse = {
-  replayStartUrl: string;
-  replayNowUrl: string;
-  sessionId: string;
+    replayStartUrl: string;
+    replayNowUrl: string;
+    sessionId: string;
 };
 
-export const LogLevel = {
-  Log: 0, // Clamps to Debug on iOS
-  Debug: 1,
-  Info: 2, // Default
-  Warn: 3,
-  Error: 4,
-  Assert: 5, // Clamps to Error on Android
-};
-
-interface FullStoryInterface {
-  LogLevel: typeof LogLevel;
-  anonymize(): void;
-  identify(string, Object): void;
-  setUserVars(Object): void;
-  onReady(): Promise<OnReadyResponse>;
-  getCurrentSession(): Promise<string>;
-  getCurrentSessionURL(): Promise<string>;
-  consent(boolean): void;
-  event(string, Object);
-  shutdown(): void;
-  restart(): void;
-  log(number, string): void;
-  resetIdleTimer(): void;
+declare const LogLevel = {
+    Log: 0, // Clamps to Debug on iOS
+    Debug: 1,
+    Info: 2, // Default
+    Warn: 3,
+    Error: 4,
+    Assert: 5 // Clamps to Error on Android
 }
 
-declare global {
-  namespace JSX {
-    interface IntrinsicAttributes {
-      fsAttribute?: {[key: string]: string};
-      fsClass?: string;
-      fsTagName?: string;
-    }
-  }
+export interface UserVars {
+    /** Explicitly sets the unique identifier for the user */
+    uid?: string;
+    /** Displays nice-looking user names */
+    displayName?: string;
+    /** Activates "Email this user" */
+    email?: string;
+
+    /**  Other Simple key/value pairs you'd like to record. */
+    [property: string]: string | boolean | number | undefined;
 }
 
-export default FullStory as FullStoryInterface;
+declare namespace FullStory {
+    let LogLevel: typeof LogLevel;
+
+    function anonymize(): void;
+
+    function identify(string: string, Object: UserVars): void;
+
+    function setUserVars(Object: UserVars): void;
+
+    function onReady(): Promise<OnReadyResponse>;
+
+    function getCurrentSession(): Promise<string>;
+
+    function getCurrentSessionURL(): Promise<string>;
+
+    function consent(boolean: boolean): void;
+
+    function event(string: string, Object: UserVars): void;
+
+    function shutdown(): void;
+
+    function restart(): void;
+
+    function log(number: number, string: string): void;
+
+    function resetIdleTimer(): void;
+}
+
+export default FullStory

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,14 +14,8 @@ export enum ILogLevel {
 }
 
 export interface UserVars {
-    /** Explicitly sets the unique identifier for the user */
-    uid?: string;
-    /** Displays nice-looking user names */
     displayName?: string;
-    /** Activates "Email this user" */
     email?: string;
-
-    /**  Other Simple key/value pairs you'd like to record. */
     [property: string]: string | boolean | number | undefined;
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -47,4 +47,14 @@ declare namespace FullStory {
     function resetIdleTimer(): void;
 }
 
+declare global {
+    namespace JSX {
+        interface IntrinsicAttributes {
+            fsAttribute?: {[key: string]: string};
+            fsClass?: string;
+            fsTagName?: string;
+        }
+    }
+}
+
 export default FullStory

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,13 +4,13 @@ export type OnReadyResponse = {
     sessionId: string;
 };
 
-declare const LogLevel = {
-    Log: 0, // Clamps to Debug on iOS
-    Debug: 1,
-    Info: 2, // Default
-    Warn: 3,
-    Error: 4,
-    Assert: 5 // Clamps to Error on Android
+export enum ILogLevel {
+    Log = 0, // Clamps to Debug on iOS
+    Debug = 1,
+    Info = 2, // Default
+    Warn = 3,
+    Error = 4,
+    Assert = 5 // Clamps to Error on Android
 }
 
 export interface UserVars {
@@ -26,7 +26,7 @@ export interface UserVars {
 }
 
 declare namespace FullStory {
-    let LogLevel: typeof LogLevel;
+    let LogLevel: ILogLevel;
 
     function anonymize(): void;
 


### PR DESCRIPTION
The  package file was wrong, referencing a js file when it should be ts. The typing were also incorrect in syntax among some other things.

Repro repo is at https://github.com/devon94/fullstoryrepro

No need to for iOS/Android linking as it is purely TypeScript issues. Babel is also not a part of this.

To reproduce: 

1.  Check out repo
2. Yarn install
3. Run `yarn tsc` (compiles TypeScript)
4. Many Failures

<img width="958" alt="image" src="https://user-images.githubusercontent.com/14797029/193359999-914b8eab-395b-4244-b4f7-79eb71362f22.png">

After my changes:

<img width="949" alt="image" src="https://user-images.githubusercontent.com/14797029/193360087-36196a31-f3dc-49dd-8ae9-8e99e8097967.png">