### PR TITLE
fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "FullStory",
   "license": "MIT",
   "main": "src/index.js",
-  "types": "src/index.d.js",
+  "types": "src/index.d.ts",
   "files": [
     "android",
     "ios",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,35 +1,37 @@
-import {NativeModules} from 'react-native';
-
-declare const {FullStory} = NativeModules;
-
 export type OnReadyResponse = {
   replayStartUrl: string;
   replayNowUrl: string;
   sessionId: string;
 };
 
-export const LogLevel = {
-  Log: 0, // Clamps to Debug on iOS
-  Debug: 1,
-  Info: 2, // Default
-  Warn: 3,
-  Error: 4,
-  Assert: 5, // Clamps to Error on Android
-};
+export enum LogLevel {
+  Log = 0, // Clamps to Debug on iOS
+  Debug = 1,
+  Info = 2, // Default
+  Warn = 3,
+  Error = 4,
+  Assert = 5, // Clamps to Error on Android
+}
 
-interface FullStoryInterface {
+interface UserVars {
+  displayName?: string;
+  email?: string;
+  [key: string]: any;
+}
+
+declare type FullStoryStatic = {
   LogLevel: typeof LogLevel;
   anonymize(): void;
-  identify(string, Object): void;
-  setUserVars(Object): void;
+  identify(uid: string, userVars?: UserVars): void;
+  setUserVars(userVars: UserVars): void;
   onReady(): Promise<OnReadyResponse>;
   getCurrentSession(): Promise<string>;
   getCurrentSessionURL(): Promise<string>;
-  consent(boolean): void;
-  event(string, Object);
+  consent(userConsents: boolean): void;
+  event(eventName: string, eventProperties: Object): void;
   shutdown(): void;
   restart(): void;
-  log(number, string): void;
+  log(logLevel: LogLevel, message: string): void;
   resetIdleTimer(): void;
 }
 
@@ -43,4 +45,5 @@ declare global {
   }
 }
 
-export default FullStory as FullStoryInterface;
+declare const FullStory: FullStoryStatic;
+export default FullStory;


### PR DESCRIPTION
Fix TypeScript compile errors when `skipLibCheck = false`. 

Error reproduction from our customer:
 
> (Using the reproduction repo from the customer: https://github.com/devon94/fullstoryrepro)
> 1. Run yarn install
> 2. Run yarn tsc (compiles TypeScript)
> 3. Observe the output errors

To simulate fix, go into `package.json` and replace with: `"@fullstory/react-native": "fullstorydev/fullstory-react-native#ryanwang5574/sc-216416/address-incorrect-typings-syntax-and-incorrect"`

Navigate into `App.tsx` and play with FullStory. You'll see that TS intellisense/autocomplete works correctly.
