### PR TITLE
CircleCI deploy from tags rather than master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,26 @@ workflows:
   test-deploy:
     jobs:
       - build-react-native
+          filters:
+             # test on branches and version tags (all branches are included by default)
+            tags:
+              only: /^v.*/
       - hold:
           type: approval
           requires:
             - build-react-native
           filters:
+            # hold only on version tags
+            tags:
+              only: /^v.*/
             branches:
-              only: "master"
+              ignore: /.*/
       - deploy-react-native:
           requires:
             - hold
+          filters:
+            # deploy only on version tags
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
This updates our CircleCI workflow to run build/test on `v*` branches (e.g. `v1.1.0`) in addition to all branches, and then it moves the hold and deployment jobs to *only* run on `v*` branches.

This is loosely based on https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/

This should resolve the issue we're currently experiencing where the CI status badge is marked as failing even though we've fixed the issue.

Unfortunately, this stuff is difficult to test until we're ready to do an actual deployment, but I think I got it right.