### PR TITLE
send React logs using FS SDK

### DIFF
--- a/ios/FullStory.m
+++ b/ios/FullStory.m
@@ -251,7 +251,7 @@ static const char *_rctview_previous_attributes_key = "associated_object_rctview
 
 @implementation LogCapture
 + (void) load {
-	RCTSetLogFunction(^(RCTLogLevel level, RCTLogSource source, NSString *fileName, NSNumber *lineNumber, NSString *message) {
+	RCTAddLogFunction(^(RCTLogLevel level, RCTLogSource source, NSString *fileName, NSNumber *lineNumber, NSString *message) {
         FSEventLogLevel levelValue;
         switch(level) {
             case RCTLogLevelTrace:

--- a/ios/FullStory.m
+++ b/ios/FullStory.m
@@ -245,3 +245,33 @@ static const char *_rctview_previous_attributes_key = "associated_object_rctview
 	} SWIZZLE_END;
 }
 @end
+
+@interface LogCapture : NSObject
+@end
+
+@implementation LogCapture
++ (void) load {
+	RCTSetLogFunction(^(RCTLogLevel level, RCTLogSource source, NSString *fileName, NSNumber *lineNumber, NSString *message) {
+        FSEventLogLevel levelValue;
+        switch(level) {
+            case RCTLogLevelTrace:
+                levelValue = FSLOG_DEBUG;
+                break;
+            case RCTLogLevelInfo:
+                levelValue = FSLOG_INFO;
+                break;
+            case RCTLogLevelWarning:
+                levelValue = FSLOG_WARNING;
+                break;
+            case RCTLogLevelError:
+            case RCTLogLevelFatal:
+                levelValue = FSLOG_ERROR;
+                break;
+        }
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [FS logWithLevel:levelValue message:message];
+        });
+  });
+}
+@end


### PR DESCRIPTION
Using this [React Native API](https://github.com/facebook/react-native/blob/3c4850d76b8f67526161211d21a9da66f866e2d6/React/Base/RCTLog.h#L111) to add a custom function that captures every iOS log and sends it to FullStory. 

Is this the best place for the function? Not sure if we can tap into the `AppDelegate` or the lifecycle like `didFinishLaunchingWithOptions` and place it there. Open to suggestions.

There's a question of potential sensitive information capture as well. How should we handle that?