### PR TITLE
WIP: pass props to views that don't

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@expo/config-plugins": "^4.1.5",
         "@fullstory/babel-plugin-annotate-react": "^2.2.0",
-        "@fullstory/babel-plugin-react-native": "^1.0.2"
+        "@fullstory/babel-plugin-react-native": "^1.0.2",
+        "hoist-non-react-statics": "^3.3.2"
       },
       "devDependencies": {
         "@tsconfig/node10": "^1.0.9",
@@ -5920,6 +5921,19 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -15795,6 +15809,21 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
           "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
           "peer": true
+        }
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "@expo/config-plugins": "^4.1.5",
     "@fullstory/babel-plugin-annotate-react": "^2.2.0",
-    "@fullstory/babel-plugin-react-native": "^1.0.2"
+    "@fullstory/babel-plugin-react-native": "^1.0.2",
+    "hoist-non-react-statics": "^3.3.2"
   },
   "peerDependencies": {
     "react": "*",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import {NativeModules} from 'react-native';
+import withFSAttributes from './withFSAttributes';
 
 const {FullStory} = NativeModules;
 
@@ -14,3 +15,5 @@ const LogLevel = {
 FullStory.LogLevel = LogLevel;
 
 export default FullStory;
+
+export {withFSAttributes};

--- a/src/withFSAttributes.js
+++ b/src/withFSAttributes.js
@@ -1,0 +1,97 @@
+import hoist from "hoist-non-react-statics";
+import React from "react";
+
+// https://github.com/facebook/react-native/blob/ccefad049abc5aac4fac59e96c6ca2307efdb57f/Libraries/StyleSheet/flattenStyle.js
+function flattenStyle(style) {
+  if (style === null || typeof style !== "object") {
+    return undefined;
+  }
+
+  if (!Array.isArray(style)) {
+    return style;
+  }
+
+  const result = {};
+  for (let i = 0, styleLength = style.length; i < styleLength; ++i) {
+    const computedStyle = flattenStyle(style[i]);
+    if (computedStyle) {
+      for (const key in computedStyle) {
+        result[key] = computedStyle[key];
+      }
+    }
+  }
+  return result;
+}
+
+// https://github.com/facebook/react-native/blob/43636267011a97490ed7495b08e500c5d0d54872/Libraries/StyleSheet/StyleSheet.js#L273
+function compose(style1, style2) {
+  if (style1 != null && style2 != null) {
+    return [style1, style2];
+  } else {
+    return style1 != null ? style1 : style2;
+  }
+}
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || "Component";
+}
+
+function merge(element, props) {
+  const { style: sourceComponentStyle } = element.props;
+  const { style: wrappedComponentStyle, ...rest } = props;
+
+  const sourceComponentStyleFlattened = flattenStyle(sourceComponentStyle);
+  const wrappedStyleFlattened = flattenStyle(wrappedComponentStyle);
+
+  const style = compose(sourceComponentStyleFlattened, wrappedStyleFlattened);
+
+  return React.cloneElement(element, {
+    ...rest,
+    style,
+  });
+}
+
+// https://github.com/colingourlay/proper-component/blob/master/src/index.js#L30
+function wrapClassComponent(SourceComponent) {
+  class WrappedComponent extends SourceComponent {
+    render() {
+      return merge(super.render(), this.props);
+    }
+  }
+
+  const ForwardRef = (props, ref) =>
+    React.createElement(
+      WrappedComponent,
+      Object.assign({ ref: typeof ref === "function" ? ref : null }, props)
+    );
+
+  WrappedComponent.displayName = ForwardRef.displayName =
+    getDisplayName(SourceComponent);
+
+  return React.forwardRef(ForwardRef);
+}
+
+function wrapFunctionalComponent(SourceComponent) {
+  const wrappedComponent = (props) => {
+    return merge(SourceComponent(props), props);
+  };
+
+  wrappedComponent.displayName = getDisplayName(SourceComponent);
+
+  return wrappedComponent;
+}
+
+const withFSAttributes = (SourceComponent) => {
+  // https://github.com/facebook/react/blob/d9e0485c84b45055ba86629dc20870faca9b5973/packages/react-refresh/src/ReactFreshRuntime.js#L144
+  const isClassComponent =
+    SourceComponent.prototype && SourceComponent.prototype.isReactComponent;
+
+  return hoist(
+    (isClassComponent ? wrapClassComponent : wrapFunctionalComponent)(
+      SourceComponent
+    ),
+    SourceComponent
+  );
+};
+
+export default withFSAttributes;


### PR DESCRIPTION
```
const CustomComponent = () => {
  return <Text>sample text</Text>
}

class CustomClassComponent extends React.Component {
  render() {
    return <Text>sample text</Text>
  }
}

const FSComponent = withFSAttributes(CustomComponent)
const FSClassComponent = withFSAttributes(CustomClassComponent)

const App = () => {
  return (
    <View>
      <FSComponent fsClass="fs-unmask" />
      <FSClassComponent fsClass="fs-unmask" />
    </View>
  )
}
```

For the above example, `CustomComponent` does not pass props to its children. Using the Higher Order Component `withFSAttributes` will pass `fsClass` and any other props to its children (top level element).

TODO - typescript and tests