### PR TITLE
Add getCurrentSessionURLNow

### DIFF
--- a/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
@@ -88,10 +88,19 @@ public class FullStoryModule extends ReactContextBaseJavaModule {
         }
     }
 
+    // The original session URL call
     @ReactMethod
     public static void getCurrentSessionURL(Promise promise) {
         if (promise != null) {
             promise.resolve(FS.getCurrentSessionURL());
+        }
+    }
+
+    // The new session URL call - get the current time
+    @ReactMethod
+    public static void getCurrentSessionURLNow(Promise promise) {
+        if (promise != null) {
+            promise.resolve(FS.getCurrentSessionURL(true));
         }
     }
 

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
@@ -95,7 +95,6 @@ public class FullStoryModule extends ReactContextBaseJavaModule {
         }
     }
 
-    // The new session URL call - get the current time
     @ReactMethod
     public static void getCurrentSessionURLNow(Promise promise) {
         if (promise != null) {

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryModule.java
@@ -88,7 +88,6 @@ public class FullStoryModule extends ReactContextBaseJavaModule {
         }
     }
 
-    // The original session URL call
     @ReactMethod
     public static void getCurrentSessionURL(Promise promise) {
         if (promise != null) {

--- a/ios/FullStory.m
+++ b/ios/FullStory.m
@@ -42,10 +42,19 @@ RCT_REMAP_METHOD(getCurrentSession, getCurrentSessionWithResolver:(RCTPromiseRes
 	});
 }
 
+// Original
 RCT_REMAP_METHOD(getCurrentSessionURL, getCurrentSessionURLWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   dispatch_async(dispatch_get_main_queue(), ^{
 		resolve(FS.currentSessionURL);
+	});
+}
+
+// Added for current session URL at current time
+RCT_REMAP_METHOD(getCurrentSessionURLNow, getCurrentSessionURLNowWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+  dispatch_async(dispatch_get_main_queue(), ^{
+		resolve([FS currentSessionURL: true]);
 	});
 }
 

--- a/ios/FullStory.m
+++ b/ios/FullStory.m
@@ -42,7 +42,6 @@ RCT_REMAP_METHOD(getCurrentSession, getCurrentSessionWithResolver:(RCTPromiseRes
 	});
 }
 
-// Original
 RCT_REMAP_METHOD(getCurrentSessionURL, getCurrentSessionURLWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   dispatch_async(dispatch_get_main_queue(), ^{
@@ -50,7 +49,6 @@ RCT_REMAP_METHOD(getCurrentSessionURL, getCurrentSessionURLWithResolver:(RCTProm
 	});
 }
 
-// Added for current session URL at current time
 RCT_REMAP_METHOD(getCurrentSessionURLNow, getCurrentSessionURLNowWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   dispatch_async(dispatch_get_main_queue(), ^{

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -27,6 +27,7 @@ declare type FullStoryStatic = {
   onReady(): Promise<OnReadyResponse>;
   getCurrentSession(): Promise<string>;
   getCurrentSessionURL(): Promise<string>;
+  getCurrentSessionURLNow(): Promise<string>;
   consent(userConsents: boolean): void;
   event(eventName: string, eventProperties: Object): void;
   shutdown(): void;


### PR DESCRIPTION
When fetching the current session, we need to get the timestamp in the session in order to jump to the correct part of the session.

This PR adds `getCurrentSessionURLNow` to the JS library, calling the native `getCurrentSessionURL` method with a parameter of `true` to get the current timestamp.