### PR TITLE
Fix expo plugin record on start arg

### DIFF
--- a/plugin/build/withFullStoryAndroid.js
+++ b/plugin/build/withFullStoryAndroid.js
@@ -53,7 +53,7 @@ const addFullStoryGradlePlugin = (appBuildGradle, { org, host, logLevel, logcatL
           ${logLevel ? `logLevel '${logLevel}'` : ""}
           ${logcatLevel ? `logcatLevel '${logcatLevel}'` : ""}
           ${enabledVariants ? `enabledVariants '${enabledVariants}'` : ""}
-          ${recordOnStart ? `recordOnStart ${recordOnStart}` : ""}
+          ${typeof recordOnStart === 'boolean' ? `recordOnStart ${recordOnStart}` : ""}
       }`,
         anchor: /./,
         offset: 1,

--- a/plugin/src/__tests__/withFullStoryAndroid.test.ts
+++ b/plugin/src/__tests__/withFullStoryAndroid.test.ts
@@ -42,4 +42,13 @@ describe("Config Plugin Android Tests", function () {
     );
     expect(result).toMatchSnapshot();
   });
+
+  it("Sets recordOnStart to false when provided", async function () {
+    let result = appBuildGradle;
+    result = addFullStoryGradlePlugin(
+      result,
+      { ...pluginConfigs, recordOnStart: false } as FullStoryAndroidProps
+    );
+    expect(result).toContain('recordOnStart false');
+  });
 });

--- a/plugin/src/withFullStoryAndroid.ts
+++ b/plugin/src/withFullStoryAndroid.ts
@@ -84,7 +84,7 @@ export const addFullStoryGradlePlugin = (
           ${logLevel ? `logLevel '${logLevel}'` : ""}
           ${logcatLevel ? `logcatLevel '${logcatLevel}'` : ""}
           ${enabledVariants ? `enabledVariants '${enabledVariants}'` : ""}
-          ${recordOnStart ? `recordOnStart ${recordOnStart}` : ""}
+          ${typeof recordOnStart === 'boolean' ? `recordOnStart ${recordOnStart}` : ""}
       }`,
     anchor: /./,
     offset: 1,


### PR DESCRIPTION
From #60 ,
The `recordOnStart` option is true by default and can optionally be disabled. The previous implementation wouldn't set the option in the app's `build.gradle` when provided a `false` value, so this PR fixes that implementation and adds a simple test.

Original contributor is inactive. Rebased off master so we can merge his contribution.
