### PR TITLE
Add Android pages implementation

### DIFF
--- a/android/src/legacy/java/com/FullStoryModule.java
+++ b/android/src/legacy/java/com/FullStoryModule.java
@@ -1,20 +1,10 @@
 package com.fullstory.reactnative;
 
-import androidx.annotation.NonNull;
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.NativeModule;
-import com.facebook.react.bridge.ReactContext;
-
-import java.util.Map;
-import java.util.HashMap;
-
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class FullStoryModule extends ReactContextBaseJavaModule {
 
@@ -88,22 +78,22 @@ public class FullStoryModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public static void createPage(String pageName, ReadableMap pageProperties) {
-        FullStoryModuleImpl.createPage(pageName, pageProperties);
+    public static void startPage(String nonce, String pageName, ReadableMap pageProperties) {
+        FullStoryModuleImpl.startPage(nonce, pageName, pageProperties);
     }
 
     @ReactMethod
-    public static void startPage(ReadableMap pageProperties) {
-        FullStoryModuleImpl.startPage(pageProperties);
+    public static void updatePage(String uuid, ReadableMap pageProperties) {
+        FullStoryModuleImpl.updatePage(uuid, pageProperties);
     }
 
     @ReactMethod
-    public static void updatePage(ReadableMap pageProperties) {
-        FullStoryModuleImpl.updatePage(pageProperties);
+    public static void endPage(String uuid) {
+        FullStoryModuleImpl.endPage(uuid);
     }
 
     @ReactMethod
-    public static void endPage() {
-        FullStoryModuleImpl.endPage();
+    public static void getUUID(Promise promise) {
+        FullStoryModuleImpl.getUUID(promise);
     }
 }

--- a/android/src/legacy/java/com/FullStoryModule.java
+++ b/android/src/legacy/java/com/FullStoryModule.java
@@ -91,9 +91,4 @@ public class FullStoryModule extends ReactContextBaseJavaModule {
     public static void endPage(String uuid) {
         FullStoryModuleImpl.endPage(uuid);
     }
-
-    @ReactMethod
-    public static void getUUID(Promise promise) {
-        FullStoryModuleImpl.getUUID(promise);
-    }
 }

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryModuleImpl.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryModuleImpl.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 public class FullStoryModuleImpl {
 
     public static final String NAME = "FullStory";
+    private static final String TAG = "FullStoryModuleImpl";
     public static final boolean reflectionSuccess;
     private static final Method PAGE_VIEW;
     private static final Method UPDATE_PAGE_PROPERTIES;
@@ -34,7 +35,7 @@ public class FullStoryModuleImpl {
             pageView = null;
             updatePageProperties = null;
             endPage = null;
-            Log.println(Log.ERROR, NAME, "Unable to access native FullStory pages API. Pages API will not function correctly. " +
+            Log.e(TAG, "Unable to access native FullStory pages API. Pages API will not function correctly. " +
                     "Make sure that your plugin is at least version 1.38; if the issue persists, please contact FullStory Support.");
         }
 
@@ -179,7 +180,7 @@ public class FullStoryModuleImpl {
             PAGE_VIEW.invoke(null, nonce, pageName, toMap(pageProperties));
         } catch (Throwable t) {
             // this should never happen
-            Log.println(Log.ERROR, NAME, "Unexpected error while calling startPage. Please contact FullStory Support.");
+            Log.e(TAG, "Unexpected error while calling startPage. Please contact FullStory Support.");
         }
     }
 
@@ -193,7 +194,7 @@ public class FullStoryModuleImpl {
             UPDATE_PAGE_PROPERTIES.invoke(null, nonce, toMap(pageProperties));
         } catch (Throwable t) {
             // this should never happen
-            Log.println(Log.ERROR, NAME, "Unexpected error while calling updatePage. Please contact FullStory Support.");
+            Log.e(TAG, "Unexpected error while calling updatePage. Please contact FullStory Support.");
         }
     }
 
@@ -206,7 +207,7 @@ public class FullStoryModuleImpl {
             END_PAGE.invoke(null, nonce);
         } catch (Throwable t) {
             // this should never happen
-            Log.println(Log.ERROR, NAME, "Unexpected error while calling endPage. Please contact FullStory Support.");
+            Log.e(TAG, "Unexpected error while calling endPage. Please contact FullStory Support.");
         }
     }
 }

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryModuleImpl.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryModuleImpl.java
@@ -1,5 +1,7 @@
 package com.fullstory.reactnative;
 
+import androidx.annotation.NonNull;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableMap;
@@ -9,9 +11,10 @@ import com.fullstory.FSPage;
 import com.fullstory.FSOnReadyListener;
 import com.fullstory.FSSessionData;
 
+import java.util.UUID;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-
+import java.lang.reflect.Method;
 public class FullStoryModuleImpl {
 
     public static final String NAME = "FullStory";
@@ -140,25 +143,42 @@ public class FullStoryModuleImpl {
         return map.toHashMap();
     }
 
-    public static void createPage(String pageName, ReadableMap pageProperties) {
-        page = FS.page(pageName, toMap(pageProperties));
-    }
+    @NonNull
+    public static String getUUID() {
+		UUID uuid = UUID.randomUUID();
+        return uuid.toString();
+	}
+    
+    public static void startPage(String uuid, String pageName, ReadableMap pageProperties) {
+        UUID nonce = UUID.fromString(uuid);
 
-    public static void startPage(ReadableMap pageProperties) {
-        if (page != null) {
-            page.start(toMap(pageProperties));
+        try {
+            Method getWebViewClientMethod = FS.class.getMethod("__pageView", UUID.class, String.class, Map.class);
+            getWebViewClientMethod.invoke(null, nonce, pageName, toMap(pageProperties));
+        } catch (Throwable t) {
+            System.out.println("Unable to invoke __pageView via reflection, please contact FullStory Support.");
         }
     }
 
-    public static  void updatePage(ReadableMap pageProperties) {
-        if (page != null) {
-            page.updateProperties(toMap(pageProperties));
+    public static void updatePage(String uuid, ReadableMap pageProperties) {
+        UUID nonce = UUID.fromString(uuid);
+
+        try {
+            Method getWebViewClientMethod = FS.class.getMethod("__updatePageProperties", UUID.class, Map.class);
+            getWebViewClientMethod.invoke(null, nonce, toMap(pageProperties));
+        } catch (Throwable t) {
+            System.out.println("Unable to invoke __updatePageProperties, please contact FullStory Support. ");
         }
     }
 
-    public static void endPage() {
-        if (page != null) {
-            page.end();
+    public static void endPage(String uuid) {
+        UUID nonce = UUID.fromString(uuid);
+
+        try {
+            Method getWebViewClientMethod = FS.class.getMethod("__endPage", UUID.class);
+            getWebViewClientMethod.invoke(null, nonce);
+        } catch (Throwable t) {
+            System.out.println("Unable to invoke __endPage, please contact FullStory Support. ");
         }
     }
 }

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryModuleImpl.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryModuleImpl.java
@@ -1,6 +1,5 @@
 package com.fullstory.reactnative;
 
-import androidx.annotation.NonNull;
 import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;
@@ -168,12 +167,6 @@ public class FullStoryModuleImpl {
         }
 
         return map.toHashMap();
-    }
-
-    @NonNull
-    public static void getUUID(Promise promise) {
-        UUID uuid = UUID.randomUUID();
-        promise.resolve(uuid.toString());
     }
 
     public static void startPage(String uuid, String pageName, ReadableMap pageProperties) {

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryModuleImpl.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryModuleImpl.java
@@ -43,7 +43,7 @@ public class FullStoryModuleImpl {
         UPDATE_PAGE_PROPERTIES = updatePageProperties;
         END_PAGE = endPage;
 
-        reflectionSuccess = PAGE_VIEW  != null && UPDATE_PAGE_PROPERTIES != null && END_PAGE != null;
+        reflectionSuccess = PAGE_VIEW != null && UPDATE_PAGE_PROPERTIES != null && END_PAGE != null;
     }
 
 
@@ -186,6 +186,7 @@ public class FullStoryModuleImpl {
             PAGE_VIEW.invoke(null, nonce, pageName, toMap(pageProperties));
         } catch (Throwable t) {
             // this should never happen
+            Log.println(Log.ERROR, NAME, "Unexpected error while calling startPage. Please contact FullStory Support.");
         }
     }
 
@@ -199,6 +200,7 @@ public class FullStoryModuleImpl {
             UPDATE_PAGE_PROPERTIES.invoke(null, nonce, toMap(pageProperties));
         } catch (Throwable t) {
             // this should never happen
+            Log.println(Log.ERROR, NAME, "Unexpected error while calling updatePage. Please contact FullStory Support.");
         }
     }
 
@@ -211,6 +213,7 @@ public class FullStoryModuleImpl {
             END_PAGE.invoke(null, nonce);
         } catch (Throwable t) {
             // this should never happen
+            Log.println(Log.ERROR, NAME, "Unexpected error while calling endPage. Please contact FullStory Support.");
         }
     }
 }

--- a/android/src/turbo/java/com/FullStoryModule.java
+++ b/android/src/turbo/java/com/FullStoryModule.java
@@ -29,6 +29,12 @@ public class FullStoryModule extends NativeFullStorySpec {
     }
 
     @Override
+    @NonNull
+    public String getUUID() {
+        return FullStoryModuleImpl.getUUID();
+    }
+
+    @Override
     public void anonymize() {
         FullStoryModuleImpl.anonymize();
     }
@@ -89,22 +95,17 @@ public class FullStoryModule extends NativeFullStorySpec {
     }
 
     @Override
-    public void createPage(String pageName, ReadableMap pageProperties) {
-        FullStoryModuleImpl.createPage(pageName, pageProperties);
+    public void startPage(String nonce, String pageName, ReadableMap pageProperties) {
+        FullStoryModuleImpl.startPage(nonce, pageName, pageProperties);
     }
 
     @Override
-    public void startPage(ReadableMap pageProperties) {
-        FullStoryModuleImpl.startPage(pageProperties);
+    public void updatePage(String uuid, ReadableMap pageProperties) {
+        FullStoryModuleImpl.updatePage(uuid, pageProperties);
     }
 
     @Override
-    public void updatePage(ReadableMap pageProperties) {
-        FullStoryModuleImpl.updatePage(pageProperties);
-    }
-
-    @Override
-    public void endPage() {
-        FullStoryModuleImpl.endPage();
+    public void endPage(String uuid) {
+        FullStoryModuleImpl.endPage(uuid);
     }
 }

--- a/android/src/turbo/java/com/FullStoryModule.java
+++ b/android/src/turbo/java/com/FullStoryModule.java
@@ -1,20 +1,9 @@
 package com.fullstory.reactnative;
 
 import androidx.annotation.NonNull;
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContextBaseJavaModule;
-import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.NativeModule;
-import com.facebook.react.bridge.ReactContext;
-
-import java.util.Map;
-import java.util.HashMap;
-
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class FullStoryModule extends NativeFullStorySpec {
 
@@ -29,8 +18,8 @@ public class FullStoryModule extends NativeFullStorySpec {
     }
 
     @Override
-    public void getUUID() {
-        return FullStoryModuleImpl.getUUID();
+    public void getUUID(Promise promise) {
+        FullStoryModuleImpl.getUUID(promise);
     }
 
     @Override

--- a/android/src/turbo/java/com/FullStoryModule.java
+++ b/android/src/turbo/java/com/FullStoryModule.java
@@ -29,8 +29,7 @@ public class FullStoryModule extends NativeFullStorySpec {
     }
 
     @Override
-    @NonNull
-    public String getUUID() {
+    public void getUUID() {
         return FullStoryModuleImpl.getUUID();
     }
 

--- a/android/src/turbo/java/com/FullStoryModule.java
+++ b/android/src/turbo/java/com/FullStoryModule.java
@@ -18,11 +18,6 @@ public class FullStoryModule extends NativeFullStorySpec {
     }
 
     @Override
-    public void getUUID(Promise promise) {
-        FullStoryModuleImpl.getUUID(promise);
-    }
-
-    @Override
     public void anonymize() {
         FullStoryModuleImpl.anonymize();
     }

--- a/src/FSPage.ts
+++ b/src/FSPage.ts
@@ -1,100 +1,102 @@
-import { NativeModules } from "react-native";
+import { NativeModules } from 'react-native';
 
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
 const FullStory = isTurboModuleEnabled
-  ? require("./NativeFullStory").default
+  ? require('./NativeFullStory').default
   : NativeModules.FullStory;
 
-const {
-    startPage,
-    endPage,
-    updatePage,
-    getUUID,
-  } = FullStory;
+const { startPage, endPage, updatePage } = FullStory;
 
 export class FSPage {
-    private pageName: string;
-    private nonce: string;
-    private properties: Object;
+  private pageName: string;
+  private nonce: string;
+  private properties: Object;
 
-    constructor(pageName: string, properties: Object = {}) {
-        this.pageName = pageName;
-        this.properties = properties;
-        this.cleanProperties();
+  constructor(pageName: string, properties: Object = {}) {
+    this.pageName = pageName;
+    this.properties = properties;
+    this.cleanProperties();
+  }
+
+  private static FS_PAGE_NAME_KEY = 'pageName';
+
+  private static generateUUID() {
+    return 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'.replace(/[x]/g, () => {
+      const char = Math.floor(Math.random() * 16);
+      return char.toString(16);
+    });
+  }
+
+  private static isObject(value) {
+    return value && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  private static merge(oldValue, newValue) {
+    // We can only merge dictionaries and do not perform recursion whenever we
+    // encounter a non-dictionary value
+    // (see com.fullstory.instrumentation FSPageImpl.java)
+    if (!FSPage.isObject(oldValue) || !FSPage.isObject(newValue)) {
+      return newValue;
+    }
+    return FSPage.mergeObjects(oldValue, newValue);
+  }
+
+  private static mergeObjects(oldObj, newObj) {
+    // return new object instance on immutable "old" object frozen by RN
+    const mergedObj = { ...oldObj };
+    for (const key in newObj) {
+      const oldInnerValue = oldObj[key];
+      if (oldObj[key]) {
+        mergedObj[key] = FSPage.merge(oldInnerValue, newObj[key]);
+      } else {
+        mergedObj[key] = newObj[key];
+      }
+    }
+    return mergedObj;
+  }
+
+  private cleanProperties() {
+    if (this.properties && this.properties[FSPage.FS_PAGE_NAME_KEY]) {
+      delete this.properties[FSPage.FS_PAGE_NAME_KEY];
+      console.warn(`${FSPage.FS_PAGE_NAME_KEY} is a reserved property and has been removed.`);
+    }
+  }
+
+  update(properties: Object) {
+    if (!this.nonce) {
+      console.error(
+        'Called `updateProperties` on FSPage that has not been `start`-ed. This may ' +
+          'be a mistake. `updateProperties` should be called on the same FSPage ' +
+          'instance that the corresponding `start` is called on.',
+      );
+      return;
     }
 
-    private static FS_PAGE_NAME_KEY = 'pageName';
+    this.properties = FSPage.merge(this.properties, properties);
+    this.cleanProperties();
+    updatePage(this.nonce, this.properties);
+  }
 
-    private static isObject(value) {
-        return (value && typeof value === 'object' && !Array.isArray(value));
+  async start(properties?: Object) {
+    if (properties) {
+      this.properties = FSPage.merge(this.properties, properties);
+      this.cleanProperties();
     }
+    this.nonce = FSPage.generateUUID();
+    startPage(this.nonce, this.pageName, this.properties);
+  }
 
-    private static merge(oldValue, newValue) {
-        // We can only merge dictionaries and do not perform recursion whenever we
-        // encounter a non-dictionary value
-        // (see com.fullstory.instrumentation FSPageImpl.java)
-        if (!FSPage.isObject(oldValue) || !FSPage.isObject(newValue)) {
-            return newValue;
-        }
-        return FSPage.mergeObjects(oldValue, newValue);
+  end() {
+    if (!this.nonce) {
+      console.error(
+        'Called `end` on FSPage that has not been `start`-ed. `end` should be ' +
+          'called on the same FSPage instance that the corresponding `start` is ' +
+          'called on.',
+      );
+      return;
     }
-
-    private static mergeObjects(oldObj, newObj) {
-        // return new object instance on immutable "old" object frozen by RN
-        const mergedObj = { ...oldObj };
-        for (const key in newObj) {
-            const oldInnerValue = oldObj[key];
-            if (oldObj[key]) {
-                mergedObj[key] = FSPage.merge(oldInnerValue, newObj[key]);
-            } else {
-                mergedObj[key] = newObj[key];
-            }
-        }
-        return mergedObj;
-    }
-
-    private cleanProperties() {
-        if (this.properties && this.properties[FSPage.FS_PAGE_NAME_KEY]) {
-            delete this.properties[FSPage.FS_PAGE_NAME_KEY];
-            console.warn(`${FSPage.FS_PAGE_NAME_KEY} is a reserved property and has been removed.`);
-        }
-    }
-
-    update(properties: Object) {
-        if (!this.nonce) {
-            console.error(
-                "Called `updateProperties` on FSPage that has not been `start`-ed. This may " +
-                "be a mistake. `updateProperties` should be called on the same FSPage " +
-                "instance that the corresponding `start` is called on."
-            );
-            return;
-        }
-
-        this.properties = FSPage.merge(this.properties, properties);
-        this.cleanProperties();
-        updatePage(this.nonce, this.properties);
-    }
-
-    async start(properties?: Object) {
-        if (properties) {
-            this.properties = FSPage.merge(this.properties, properties);
-            this.cleanProperties();
-        }
-        this.nonce = await getUUID();
-        startPage(this.nonce, this.pageName, this.properties);
-    }
-    
-    end() {
-        if (!this.nonce) {
-            console.error(
-                "Called `end` on FSPage that has not been `start`-ed. `end` should be " +
-                    "called on the same FSPage instance that the corresponding `start` is " +
-                    "called on."
-            );
-            return;
-        }
-        endPage(this.nonce);
-        this.nonce = '';
-    }
+    endPage(this.nonce);
+    this.nonce = '';
+  }
 }

--- a/src/FSPage.ts
+++ b/src/FSPage.ts
@@ -78,7 +78,7 @@ export class FSPage {
     updatePage(this.nonce, this.properties);
   }
 
-  async start(properties?: Object) {
+  start(properties?: Object) {
     if (properties) {
       this.properties = FSPage.merge(this.properties, properties);
       this.cleanProperties();

--- a/src/FSPage.ts
+++ b/src/FSPage.ts
@@ -1,0 +1,109 @@
+import { NativeModules } from "react-native";
+
+const isTurboModuleEnabled = global.__turboModuleProxy != null;
+
+const FullStory = isTurboModuleEnabled
+  ? require("./NativeFullStory").default
+  : NativeModules.FullStory;
+
+const {
+    startPage,
+    endPage,
+    updatePage,
+    getUUID,
+  } = FullStory;
+
+export default class FSPage {
+    private pageName: string;
+    private nonce: string;
+    private properties: Object;
+
+    constructor(pageName: string, properties: Object = {}) {
+        this.pageName = pageName;
+        this.properties = properties;
+        this.cleanProperties();
+    }
+
+    static FS_PAGE_NAME_KEY = 'pageName';
+
+    static isObject(value) {
+        return (value && typeof value === 'object' && !Array.isArray(value));
+    }
+
+    static merge(oldValue, newValue) {
+        // We can only merge dictionaries and do not perform recursion whenever we
+        // encounter a non-dictionary value
+        // (see com.fullstory.instrumentation FSPageImpl.java)
+        if (!FSPage.isObject(oldValue) || !FSPage.isObject(newValue)) {
+            return newValue;
+        }
+        return FSPage.mergeObjects(oldValue, newValue);
+    }
+
+    static mergeObjects(oldObj, newObj) {
+        if (!newObj) return oldObj;
+
+        for (const key in newObj) {
+            const oldInnerValue = oldObj[key];
+            if (oldObj[key]) {
+                oldObj[key] = FSPage.merge(oldInnerValue, newObj[key]);
+            } else {
+                oldObj[key] = newObj[key];
+            }
+        }
+      
+        return oldObj;
+    }
+
+    cleanProperties() {
+        if (this.properties && this.properties[FSPage.FS_PAGE_NAME_KEY]) {
+            delete this.properties[FSPage.FS_PAGE_NAME_KEY];
+            console.warn(`${FSPage.FS_PAGE_NAME_KEY} is a reserved property and has been removed.`);
+        }
+    }
+
+    update(properties: Object) {
+        if (!this.nonce) {
+            console.error(
+                "Called `updateProperties` on FSPage that has not been `start`-ed. This may " +
+                "be a mistake. `updateProperties` should be called on the same FSPage " +
+                "instance that the corresponding `start` is called on."
+            );
+            return;
+        }
+
+        FSPage.merge(this.properties, properties);
+        this.cleanProperties();
+        updatePage(this.nonce, this.properties);
+    }
+
+    start(properties?: Object) {
+        if (properties) {
+            FSPage.merge(this.properties, properties);
+            this.cleanProperties();
+        }
+        this.nonce = getUUID();
+        startPage(this.nonce, this.pageName, this.properties);
+    }
+    
+    end() {
+        if (!this.nonce) {
+            console.error(
+                "Called `end` on FSPage that has not been `start`-ed. `end` should be " +
+                    "called on the same FSPage instance that the corresponding `start` is " +
+                    "called on."
+            );
+            return;
+        }
+        endPage(this.nonce);
+        this.nonce = '';
+    }
+
+    getPageName() {
+        return this.pageName;
+    }
+
+    getProperties() {
+        return this.properties;
+    }
+}

--- a/src/NativeFullStory.ts
+++ b/src/NativeFullStory.ts
@@ -18,6 +18,7 @@ export interface Spec extends TurboModule {
   startPage(nonce: string, pageName: string, pageProperties?: Object): void;
   endPage(uuid: string): void;
   updatePage(pageProperties: Object): void;
+  getUUID(): string;
 }
 
 export default TurboModuleRegistry.get<Spec>('FullStory');

--- a/src/NativeFullStory.ts
+++ b/src/NativeFullStory.ts
@@ -18,7 +18,6 @@ export interface Spec extends TurboModule {
   startPage(nonce: string, pageName: string, pageProperties?: Object): void;
   endPage(uuid: string): void;
   updatePage(uuid: string, pageProperties: Object): void;
-  getUUID(): Promise<string>;
 }
 
 export default TurboModuleRegistry.get<Spec>('FullStory');

--- a/src/NativeFullStory.ts
+++ b/src/NativeFullStory.ts
@@ -15,9 +15,8 @@ export interface Spec extends TurboModule {
   restart(): void;
   log(logLevel: number, message: string): void;
   resetIdleTimer(): void;
-  createPage(pageName: string, pageProperties?: Object): void;
-  startPage(pageProperties?: Object): void;
-  endPage(): void;
+  startPage(nonce: string, pageName: string, pageProperties?: Object): void;
+  endPage(uuid: string): void;
   updatePage(pageProperties: Object): void;
 }
 

--- a/src/NativeFullStory.ts
+++ b/src/NativeFullStory.ts
@@ -17,8 +17,8 @@ export interface Spec extends TurboModule {
   resetIdleTimer(): void;
   startPage(nonce: string, pageName: string, pageProperties?: Object): void;
   endPage(uuid: string): void;
-  updatePage(pageProperties: Object): void;
-  getUUID(): string;
+  updatePage(uuid: string, pageProperties: Object): void;
+  getUUID(): Promise<string>;
 }
 
 export default TurboModuleRegistry.get<Spec>('FullStory');

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -33,9 +33,6 @@ declare type FullStoryStatic = {
   restart(): void;
   log(logLevel: LogLevel, message: string): void;
   resetIdleTimer(): void;
-  startPage(nonce: string, pageName: string, pageProperties?: Object): void;
-  endPage(): void;
-  updatePage(pageProperties: Object): void;
 };
 
 declare global {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,5 +48,20 @@ declare global {
   }
 }
 
+export declare class FSPage {
+  private pageName;
+  private nonce;
+  private properties;
+  constructor(pageName: string, properties?: Object);
+  private static FS_PAGE_NAME_KEY;
+  private static isObject;
+  private static merge;
+  private static mergeObjects;
+  private cleanProperties;
+  update(properties: Object): void;
+  start(properties?: Object): Promise<void>;
+  end(): void;
+}
+
 declare const FullStory: FullStoryStatic;
 export default FullStory;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -33,8 +33,7 @@ declare type FullStoryStatic = {
   restart(): void;
   log(logLevel: LogLevel, message: string): void;
   resetIdleTimer(): void;
-  createPage(pageName: string, pageProperties?: Object): void;
-  startPage(pageProperties?: Object): void;
+  startPage(nonce: string, pageName: string, pageProperties?: Object): void;
   endPage(): void;
   updatePage(pageProperties: Object): void;
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -56,7 +56,7 @@ export declare class FSPage {
   private static mergeObjects;
   private cleanProperties;
   update(properties: Object): void;
-  start(properties?: Object): Promise<void>;
+  start(properties?: Object): void;
   end(): void;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import { NativeModules } from 'react-native';
-
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
 const FullStory = isTurboModuleEnabled
@@ -19,7 +18,6 @@ const {
   restart,
   log,
   resetIdleTimer,
-  createPage,
   startPage,
   endPage,
   updatePage,
@@ -34,9 +32,11 @@ const LogLevel = {
   Assert: 5, // Clamps to Error on Android
 };
 
-const createPageWithProperties = (pageName, pageProperties = {}) => createPage(pageName, pageProperties);
-const startPageWithProperties = (pageProperties = {}) => startPage(pageProperties);
+const startPageWithProperties = (nonce, pageName, pageProperties = {}) =>
+  startPage(nonce, pageName, pageProperties);
 const identifyWithProperties = (uid, userVars = {}) => identify(uid, userVars);
+
+export { FSPage } from './FSPage';
 
 export default {
   anonymize,
@@ -52,7 +52,6 @@ export default {
   log,
   resetIdleTimer,
   LogLevel,
-  createPage: createPageWithProperties,
   startPage: startPageWithProperties,
   endPage,
   updatePage,

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { NativeModules } from 'react-native';
+
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
 const FullStory = isTurboModuleEnabled

--- a/src/index.js
+++ b/src/index.js
@@ -18,9 +18,6 @@ const {
   restart,
   log,
   resetIdleTimer,
-  startPage,
-  endPage,
-  updatePage,
 } = FullStory;
 
 const LogLevel = {
@@ -32,8 +29,6 @@ const LogLevel = {
   Assert: 5, // Clamps to Error on Android
 };
 
-const startPageWithProperties = (nonce, pageName, pageProperties = {}) =>
-  startPage(nonce, pageName, pageProperties);
 const identifyWithProperties = (uid, userVars = {}) => identify(uid, userVars);
 
 export { FSPage } from './FSPage';
@@ -52,7 +47,4 @@ export default {
   log,
   resetIdleTimer,
   LogLevel,
-  startPage: startPageWithProperties,
-  endPage,
-  updatePage,
 };


### PR DESCRIPTION
Post design doc approval:

- update legacy RN native module method declarations
- replace System.out with android.util.Log
- initialize reflected methods once
- getUUID is async
- fix page properties merge
- add TS FSPage types

RN Fabric [session](https://app.staging.fullstory.com/ui/KWH/session/6630689065336832:5887655561068544)
RN old architecture [session](https://app.staging.fullstory.com/ui/KWH/session/4994683218886656:5840084033536000)

This merges into branch `add-pages-api`. Additional work needed:
- iOS implementation
- add a testing framework to this plugin to test FSPage
