### PR TITLE
fix turbo module compatibility

### DIFF
--- a/android/src/main/java/com/fullstory/reactnative/FullStoryPackage.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryPackage.java
@@ -2,6 +2,7 @@ package com.fullstory.reactnative;
 
 import androidx.annotation.Nullable;
 
+import com.facebook.react.ReactPackage;
 import com.facebook.react.TurboReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -11,7 +12,7 @@ import com.facebook.react.module.model.ReactModuleInfoProvider;
 import java.util.HashMap;
 import java.util.Map;
 
-public class FullStoryPackage extends TurboReactPackage {
+public class FullStoryPackage extends TurboReactPackage implements ReactPackage {
     @Nullable
     @Override
     public NativeModule getModule(String name, ReactApplicationContext reactContext) {
@@ -24,21 +25,25 @@ public class FullStoryPackage extends TurboReactPackage {
 
     @Override
     public ReactModuleInfoProvider getReactModuleInfoProvider() {
-        return () -> {
-            final Map<String, ReactModuleInfo> moduleInfos = new HashMap<>();
-            boolean isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
-            moduleInfos.put(
-                    FullStoryModuleImpl.NAME,
-                    new ReactModuleInfo(
-                            FullStoryModuleImpl.NAME,
-                            FullStoryModuleImpl.NAME,
-                            false, // canOverrideExistingModule
-                            false, // needsEagerInit
-                            true, // hasConstants
-                            false, // isCxxModule
-                            isTurboModule // isTurboModule
-            ));
-            return moduleInfos;
+        final Map<String, ReactModuleInfo> moduleInfos = new HashMap<>();
+        boolean isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+        moduleInfos.put(
+                FullStoryModuleImpl.NAME,
+                new ReactModuleInfo(
+                        FullStoryModuleImpl.NAME,
+                        FullStoryModuleImpl.NAME,
+                        false, // canOverrideExistingModule
+                        false, // needsEagerInit
+                        true, // hasConstants
+                        false, // isCxxModule
+                        isTurboModule // isTurboModule
+        ));
+
+        return new ReactModuleInfoProvider() {
+            @Override
+            public Map<String, ReactModuleInfo> getReactModuleInfos() {
+                return moduleInfos;
+            }
         };
     }
 }


### PR DESCRIPTION
The recent `1.2.0` change prevented Native Module auto-linking for RN versions <=0.64. This caused RN apps to ignore our plugin and skipped our Native Prop rewriting, which caused API's to be unavailable. 

* remove lambda return syntax to support older Java versions
* implement `ReactPackage` so that older RN versions will auto link package

RN 63: https://app.staging.fullstory.com/ui/KWH/session/4919025558028288:5155602586599424
RN 64: https://app.staging.fullstory.com/ui/KWH/session/5415893039775744:6641882059177984
RN65: https://app.fullstory.com/ui/H0SZW/session/5320765840961536:6169443359141888
RN69: https://app.staging.fullstory.com/ui/KWH/session/5010370993782784:4913375658573824
RN72 Non-Fabric: https://app.staging.fullstory.com/ui/KWH/session/6630689065336832:4980603036827648
RN72 Fabric: https://app.staging.fullstory.com/ui/KWH/session/6630689065336832:5680769620443136  

