### PR TITLE
Auto capture console logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11674,9 +11674,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
       "peer": true
     },
     "node_modules/ip-regex": {
@@ -19251,9 +19251,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-      "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,10 @@
         "eslint-config-universe": "^12.0.0",
         "eslint-plugin-jest": "^27.2.3",
         "expo": "^49.0.0",
-        "jest": "^29.7.0",
+        "jest": "^29.0.0",
         "prettier": "3.0.2",
         "react-native-builder-bob": "^0.21.3",
-        "ts-jest": "^29.1.1",
+        "ts-jest": "^29.0.0",
         "typescript": "^4.9.5"
       },
       "peerDependencies": {
@@ -6856,6 +6856,29 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.11",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.45",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.45.tgz",
+      "integrity": "sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
       "dev": true
     },
     "node_modules/@types/semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,10 @@
         "eslint-config-universe": "^12.0.0",
         "eslint-plugin-jest": "^27.2.3",
         "expo": "^49.0.0",
-        "jest": "^29.0.0",
+        "jest": "^29.7.0",
         "prettier": "3.0.2",
         "react-native-builder-bob": "^0.21.3",
-        "ts-jest": "^29.0.0",
+        "ts-jest": "^29.1.1",
         "typescript": "^4.9.5"
       },
       "peerDependencies": {
@@ -6856,29 +6856,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
-    },
-    "node_modules/@types/react": {
-      "version": "18.2.21",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
-      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
-      "dev": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
       "dev": true
     },
     "node_modules/@types/semver": {

--- a/plugin/src/__tests__/__snapshots__/withFullStoryAndroid.test.ts.snap
+++ b/plugin/src/__tests__/__snapshots__/withFullStoryAndroid.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Config Plugin Android Tests Adds FullStory module to app build.gradle 1`] = `
-"apply plugin: \\"com.android.application\\"
+"apply plugin: "com.android.application"
 // @generated begin @fullstory/react-native plugin - expo prebuild (DO NOT MODIFY) sync-bb646efbc963bea134722dca84206580df424525
 apply plugin: 'fullstory'
       fullstory {
@@ -23,19 +23,19 @@ import com.android.build.OutputFile
  * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
  * bundle directly from the development server. Below you can see all the possible configurations
  * and their defaults. If you decide to add a configuration block, make sure to add it before the
- * \`apply from: \\"../../node_modules/react-native/react.gradle\\"\` line.
+ * \`apply from: "../../node_modules/react-native/react.gradle"\` line.
  *
  * project.ext.react = [
  *   // the name of the generated asset file containing your JS bundle
- *   bundleAssetName: \\"index.android.bundle\\",
+ *   bundleAssetName: "index.android.bundle",
  *
  *   // the entry file for bundle generation. If none specified and
- *   // \\"index.android.js\\" exists, it will be used. Otherwise \\"index.js\\" is
+ *   // "index.android.js" exists, it will be used. Otherwise "index.js" is
  *   // default. Can be overridden with ENTRY_FILE environment variable.
- *   entryFile: \\"index.android.js\\",
+ *   entryFile: "index.android.js",
  *
  *   // https://reactnative.dev/docs/performance#enable-the-ram-format
- *   bundleCommand: \\"ram-bundle\\",
+ *   bundleCommand: "ram-bundle",
  *
  *   // whether to bundle JS and assets in debug mode
  *   bundleInDebug: false,
@@ -59,32 +59,32 @@ import com.android.build.OutputFile
  *   //         'devDisabledIn\${productFlavor}\${buildType}'
  *   //         'devDisabledIn\${buildType}'
  *
- *   // the root of your project, i.e. where \\"package.json\\" lives
- *   root: \\"../../\\",
+ *   // the root of your project, i.e. where "package.json" lives
+ *   root: "../../",
  *
  *   // where to put the JS bundle asset in debug mode
- *   jsBundleDirDebug: \\"$buildDir/intermediates/assets/debug\\",
+ *   jsBundleDirDebug: "$buildDir/intermediates/assets/debug",
  *
  *   // where to put the JS bundle asset in release mode
- *   jsBundleDirRelease: \\"$buildDir/intermediates/assets/release\\",
+ *   jsBundleDirRelease: "$buildDir/intermediates/assets/release",
  *
  *   // where to put drawable resources / React Native assets, e.g. the ones you use via
  *   // require('./image.png')), in debug mode
- *   resourcesDirDebug: \\"$buildDir/intermediates/res/merged/debug\\",
+ *   resourcesDirDebug: "$buildDir/intermediates/res/merged/debug",
  *
  *   // where to put drawable resources / React Native assets, e.g. the ones you use via
  *   // require('./image.png')), in release mode
- *   resourcesDirRelease: \\"$buildDir/intermediates/res/merged/release\\",
+ *   resourcesDirRelease: "$buildDir/intermediates/res/merged/release",
  *
  *   // by default the gradle tasks are skipped if none of the JS files or assets change; this means
  *   // that we don't look at files in android/ or ios/ to determine whether the tasks are up to
  *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
  *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
  *   // for example, you might want to remove it from here.
- *   inputExcludes: [\\"android/**\\", \\"ios/**\\"],
+ *   inputExcludes: ["android/**", "ios/**"],
  *
  *   // override which node gets called and with what additional arguments
- *   nodeExecutableAndArgs: [\\"node\\"],
+ *   nodeExecutableAndArgs: ["node"],
  *
  *   // supply additional arguments to the packager
  *   extraPackagerArgs: []
@@ -94,14 +94,14 @@ import com.android.build.OutputFile
 def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
 
 project.ext.react = [
-    entryFile: [\\"node\\", \\"-e\\", \\"require('expo/scripts/resolveAppEntry')\\", projectRoot, \\"android\\"].execute(null, rootDir).text.trim(),
-    enableHermes: (findProperty('expo.jsEngine') ?: \\"jsc\\") == \\"hermes\\",
-    cliPath: new File([\\"node\\", \\"--print\\", \\"require.resolve('react-native/package.json')\\"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + \\"/cli.js\\",
-    hermesCommand: new File([\\"node\\", \\"--print\\", \\"require.resolve('hermes-engine/package.json')\\"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + \\"/%OS-BIN%/hermesc\\",
-    composeSourceMapsPath: new File([\\"node\\", \\"--print\\", \\"require.resolve('react-native/package.json')\\"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + \\"/scripts/compose-source-maps.js\\",
+    entryFile: ["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android"].execute(null, rootDir).text.trim(),
+    enableHermes: (findProperty('expo.jsEngine') ?: "jsc") == "hermes",
+    cliPath: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/cli.js",
+    hermesCommand: new File(["node", "--print", "require.resolve('hermes-engine/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/%OS-BIN%/hermesc",
+    composeSourceMapsPath: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/scripts/compose-source-maps.js",
 ]
 
-apply from: new File([\\"node\\", \\"--print\\", \\"require.resolve('react-native/package.json')\\"].execute(null, rootDir).text.trim(), \\"../react.gradle\\")
+apply from: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), "../react.gradle")
 
 /**
  * Set this to true to create two separate APKs instead of one:
@@ -138,29 +138,29 @@ def jscFlavor = 'org.webkit:android-jsc:+'
  * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
  * and the benefits of using Hermes will therefore be sharply reduced.
  */
-def enableHermes = project.ext.react.get(\\"enableHermes\\", false);
+def enableHermes = project.ext.react.get("enableHermes", false);
 
 /**
  * Architectures to build native code for in debug.
  */
-def nativeArchitectures = project.getProperties().get(\\"reactNativeDebugArchitectures\\")
+def nativeArchitectures = project.getProperties().get("reactNativeDebugArchitectures")
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        applicationId \\"com.helloworld\\"
+        applicationId "com.helloworld"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName \\"1.0\\"
+        versionName "1.0"
     }
     splits {
         abi {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
-            include \\"armeabi-v7a\\", \\"x86\\", \\"arm64-v8a\\", \\"x86_64\\"
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
     signingConfigs {
@@ -185,7 +185,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile(\\"proguard-android.txt\\"), \\"proguard-rules.pro\\"
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
 
@@ -194,7 +194,7 @@ android {
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
             // https://developer.android.com/studio/build/configure-apk-splits.html
-            def versionCodes = [\\"armeabi-v7a\\": 1, \\"x86\\": 2, \\"arm64-v8a\\": 3, \\"x86_64\\": 4]
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =
@@ -208,16 +208,16 @@ android {
 // Apply static values from \`gradle.properties\` to the \`android.packagingOptions\`
 // Accepts values in comma delimited lists, example:
 // android.packagingOptions.pickFirsts=/LICENSE,**/picasa.ini
-[\\"pickFirsts\\", \\"excludes\\", \\"merges\\", \\"doNotStrip\\"].each { prop ->
+["pickFirsts", "excludes", "merges", "doNotStrip"].each { prop ->
     // Split option: 'foo,bar' -> ['foo', 'bar']
-    def options = (findProperty(\\"android.packagingOptions.$prop\\") ?: \\"\\").split(\\",\\");
+    def options = (findProperty("android.packagingOptions.$prop") ?: "").split(",");
     // Trim all elements in place.
     for (i in 0..<options.size()) options[i] = options[i].trim();
-    // \`[] - \\"\\"\` is essentially \`[\\"\\"].filter(Boolean)\` removing all empty strings.
-    options -= \\"\\"
+    // \`[] - ""\` is essentially \`[""].filter(Boolean)\` removing all empty strings.
+    options -= ""
 
     if (options.length > 0) {
-        println \\"android.packagingOptions.$prop += $options ($options.length)\\"
+        println "android.packagingOptions.$prop += $options ($options.length)"
         // Ex: android.packagingOptions.pickFirsts += '**/SCCS/**'
         options.each {
             android.packagingOptions[prop] += it
@@ -226,13 +226,13 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: \\"libs\\", include: [\\"*.jar\\"])
+    implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
-    implementation \\"com.facebook.react:react-native:+\\"  // From node_modules
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 
-    def isGifEnabled = (findProperty('expo.gif.enabled') ?: \\"\\") == \\"true\\";
-    def isWebpEnabled = (findProperty('expo.webp.enabled') ?: \\"\\") == \\"true\\";
-    def isWebpAnimatedEnabled = (findProperty('expo.webp.animated') ?: \\"\\") == \\"true\\";
+    def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
+    def isWebpEnabled = (findProperty('expo.webp.enabled') ?: "") == "true";
+    def isWebpAnimatedEnabled = (findProperty('expo.webp.animated') ?: "") == "true";
 
     // If your app supports Android versions before Ice Cream Sandwich (API level 14)
     // All fresco packages should use the same version
@@ -255,21 +255,21 @@ dependencies {
         }
     }
     
-    implementation \\"androidx.swiperefreshlayout:swiperefreshlayout:1.0.0\\"
-    debugImplementation(\\"com.facebook.flipper:flipper:\${FLIPPER_VERSION}\\") {
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    debugImplementation("com.facebook.flipper:flipper:\${FLIPPER_VERSION}") {
         exclude group:'com.facebook.fbjni'
     }
-    debugImplementation(\\"com.facebook.flipper:flipper-network-plugin:\${FLIPPER_VERSION}\\") {
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:\${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'
         exclude group:'com.squareup.okhttp3', module:'okhttp'
     }
-    debugImplementation(\\"com.facebook.flipper:flipper-fresco-plugin:\${FLIPPER_VERSION}\\") {
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:\${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'
     }
 
     if (enableHermes) {
-        debugImplementation files(new File([\\"node\\", \\"--print\\", \\"require.resolve('hermes-engine/package.json')\\"].execute(null, rootDir).text.trim(), \\"../android/hermes-debug.aar\\"))
-        releaseImplementation files(new File([\\"node\\", \\"--print\\", \\"require.resolve('hermes-engine/package.json')\\"].execute(null, rootDir).text.trim(), \\"../android/hermes-release.aar\\"))
+        debugImplementation files(new File(["node", "--print", "require.resolve('hermes-engine/package.json')"].execute(null, rootDir).text.trim(), "../android/hermes-debug.aar"))
+        releaseImplementation files(new File(["node", "--print", "require.resolve('hermes-engine/package.json')"].execute(null, rootDir).text.trim(), "../android/hermes-release.aar"))
     } else {
         implementation jscFlavor
     }
@@ -282,7 +282,7 @@ task copyDownloadableDepsToLibs(type: Copy) {
     into 'libs'
 }
 
-apply from: new File([\\"node\\", \\"--print\\", \\"require.resolve('@react-native-community/cli-platform-android/package.json')\\"].execute(null, rootDir).text.trim(), \\"../native_modules.gradle\\");
+apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json')"].execute(null, rootDir).text.trim(), "../native_modules.gradle");
 applyNativeModulesAppBuildGradle(project)"
 `;
 
@@ -291,11 +291,11 @@ exports[`Config Plugin Android Tests Adds FullStory module to project build.grad
 
 buildscript {
     ext {
-        buildToolsVersion = \\"30.0.2\\"
+        buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 30
         targetSdkVersion = 30
-        ndkVersion = \\"21.4.7075529\\"
+        ndkVersion = "21.4.7075529"
     }
     repositories {
 // @generated begin @fullstory/react-native repositories - expo prebuild (DO NOT MODIFY) sync-e9d20c521b016225eb51e3030e69288fa97e3950
@@ -309,7 +309,7 @@ maven { url 'https://maven.fullstory.com' }
 // @generated begin @fullstory/react-native dependencies - expo prebuild (DO NOT MODIFY) sync-cec37541b39163b903cea447d84d523fb89303d4
 classpath 'com.fullstory:gradle-plugin-local:1.27.1'
 // @generated end @fullstory/react-native dependencies
-        classpath(\\"com.android.tools.build:gradle:4.2.2\\")
+        classpath("com.android.tools.build:gradle:4.2.2")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -321,11 +321,11 @@ allprojects {
         mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url(new File([\\"node\\", \\"--print\\", \\"require.resolve('react-native/package.json')\\"].execute(null, rootDir).text.trim(), \\"../android\\"))
+            url(new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), "../android"))
         }
         maven {
             // Android JSC is installed from npm
-            url(new File([\\"node\\", \\"--print\\", \\"require.resolve('jsc-android/package.json')\\"].execute(null, rootDir).text.trim(), \\"../dist\\"))
+            url(new File(["node", "--print", "require.resolve('jsc-android/package.json')"].execute(null, rootDir).text.trim(), "../dist"))
         }
 
         google()

--- a/plugin/src/__tests__/__snapshots__/withFullStoryIos.test.ts.snap
+++ b/plugin/src/__tests__/__snapshots__/withFullStoryIos.test.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Config Plugin iOS Tests Adds FullStory to Podfile 1`] = `
-"require File.join(File.dirname(\`node --print \\"require.resolve('expo/package.json')\\"\`), \\"scripts/autolinking\\")
-require File.join(File.dirname(\`node --print \\"require.resolve('react-native/package.json')\\"\`), \\"scripts/react_native_pods\\")
-require File.join(File.dirname(\`node --print \\"require.resolve('@react-native-community/cli-platform-ios/package.json')\\"\`), \\"native_modules\\")
+"require File.join(File.dirname(\`node --print "require.resolve('expo/package.json')"\`), "scripts/autolinking")
+require File.join(File.dirname(\`node --print "require.resolve('react-native/package.json')"\`), "scripts/react_native_pods")
+require File.join(File.dirname(\`node --print "require.resolve('@react-native-community/cli-platform-ios/package.json')"\`), "native_modules")
 
 platform :ios, '12.0'
 

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,4 +1,9 @@
 import { NativeModules } from 'react-native';
 import { jest } from '@jest/globals';
 
-NativeModules.FullStory = { startPage: jest.fn(), endPage: jest.fn(), updatePage: jest.fn() };
+NativeModules.FullStory = {
+  startPage: jest.fn(),
+  endPage: jest.fn(),
+  updatePage: jest.fn(),
+  log: jest.fn(),
+};

--- a/src/FSPage.ts
+++ b/src/FSPage.ts
@@ -1,7 +1,5 @@
 import { NativeModules } from 'react-native';
-import { generateUUID } from './utils';
-
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+import { generateUUID, isTurboModuleEnabled } from './utils';
 
 type PropertiesWithoutPageName = {
   [key: string]: unknown;

--- a/src/FSPage.ts
+++ b/src/FSPage.ts
@@ -1,7 +1,6 @@
 import { NativeModules } from 'react-native';
 import { generateUUID } from './utils';
 
-// @ts-expect-error
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
 type PropertiesWithoutPageName = {

--- a/src/__tests__/consoleCapture.test.ts
+++ b/src/__tests__/consoleCapture.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { NativeModules } from 'react-native';
+import { enableConsoleCapture, LogLevel } from '../logging/consoleCapture';
+
+describe('consoleCapture', () => {
+  beforeAll(() => {
+    enableConsoleCapture();
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Captures all log methods', () => {
+    const FSLog = NativeModules.FullStory.log;
+
+    console.log('goodlog0');
+    console.trace('goodtrace0');
+    console.debug('gooddebug0');
+    console.info('goodinfo0');
+    console.warn('goodwarn0');
+    console.error('gooderror0');
+
+    expect(FSLog).toBeCalledTimes(6);
+    expect(FSLog).toHaveBeenCalledWith(LogLevel.Log, '"goodlog0"');
+    expect(FSLog).toHaveBeenCalledWith(LogLevel.Debug, '"goodtrace0"');
+    expect(FSLog).toHaveBeenCalledWith(LogLevel.Debug, '"gooddebug0"');
+    expect(FSLog).toHaveBeenCalledWith(LogLevel.Info, '"goodinfo0"');
+    expect(FSLog).toHaveBeenCalledWith(LogLevel.Warn, '"goodwarn0"');
+    expect(FSLog).toHaveBeenCalledWith(LogLevel.Error, '"gooderror0"');
+  });
+
+  it('enableConsoleCapture should be idempotent', () => {
+    enableConsoleCapture();
+    enableConsoleCapture();
+
+    const FSLog = NativeModules.FullStory.log;
+
+    console.log('hello', 'goodbye', 'afternoon');
+    expect(FSLog).toBeCalledTimes(1);
+    expect(FSLog).toHaveBeenCalledWith(LogLevel.Log, '"hello" "goodbye" "afternoon"');
+  });
+});

--- a/src/__tests__/consoleCapture.test.ts
+++ b/src/__tests__/consoleCapture.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from '@jest/globals';
 import { NativeModules } from 'react-native';
 import consoleWatcher, { LogLevel } from '../logging/consoleCapture';
 
+// must run in 'silent' mode or console.trace will call into console.error
 describe('consoleCapture', () => {
   const oldConsoleLog = console.log;
   const oldConsoleTrace = console.trace;

--- a/src/__tests__/consoleCapture.test.ts
+++ b/src/__tests__/consoleCapture.test.ts
@@ -1,12 +1,22 @@
 import { describe, it, expect, afterEach } from '@jest/globals';
 import { NativeModules } from 'react-native';
-import { enableConsoleCapture, LogLevel } from '../logging/consoleCapture';
+import consoleWatcher, { LogLevel } from '../logging/consoleCapture';
 
 describe('consoleCapture', () => {
-  beforeAll(() => {
-    enableConsoleCapture();
+  const oldConsoleLog = console.log;
+  const oldConsoleTrace = console.trace;
+  const oldConsoleDebug = console.debug;
+  const oldConsoleInfo = console.info;
+  const oldConsoleWarn = console.warn;
+  const oldConsoleError = console.error;
+
+  beforeEach(() => {
+    consoleWatcher.enable();
   });
   afterEach(() => {
+    consoleWatcher.disable();
+    // reset overwrite
+    console.log = oldConsoleLog;
     jest.clearAllMocks();
   });
 
@@ -29,14 +39,110 @@ describe('consoleCapture', () => {
     expect(FSLog).toHaveBeenCalledWith(LogLevel.Error, '"gooderror0"');
   });
 
-  it('enableConsoleCapture should be idempotent', () => {
-    enableConsoleCapture();
-    enableConsoleCapture();
+  it('enableConsole and disableConsole should be idempotent', () => {
+    consoleWatcher.enable();
+    consoleWatcher.enable();
 
     const FSLog = NativeModules.FullStory.log;
 
     console.log('hello', 'goodbye', 'afternoon');
     expect(FSLog).toBeCalledTimes(1);
     expect(FSLog).toHaveBeenCalledWith(LogLevel.Log, '"hello" "goodbye" "afternoon"');
+
+    consoleWatcher.disable();
+    consoleWatcher.disable();
+
+    console.log('hello', 'goodbye', 'afternoon');
+    expect(FSLog).toBeCalledTimes(1);
+  });
+
+  it('disableConsole disables console capture', () => {
+    consoleWatcher.disable();
+
+    const FSLog = NativeModules.FullStory.log;
+
+    console.log('hello');
+    expect(FSLog).toBeCalledTimes(0);
+  });
+
+  it('disableConsole restores native console methods', () => {
+    expect(oldConsoleLog).not.toEqual(console.log);
+    expect(oldConsoleTrace).not.toEqual(console.trace);
+    expect(oldConsoleDebug).not.toEqual(console.debug);
+    expect(oldConsoleInfo).not.toEqual(console.info);
+    expect(oldConsoleWarn).not.toEqual(console.warn);
+    expect(oldConsoleError).not.toEqual(console.error);
+
+    consoleWatcher.disable();
+
+    expect(oldConsoleLog).toEqual(console.log);
+    expect(oldConsoleTrace).toEqual(console.trace);
+    expect(oldConsoleDebug).toEqual(console.debug);
+    expect(oldConsoleInfo).toEqual(console.info);
+    expect(oldConsoleWarn).toEqual(console.warn);
+    expect(oldConsoleError).toEqual(console.error);
+  });
+
+  it('disableConsole does not overwrite third party overwrites', () => {
+    let thirdPartyCall = 0;
+
+    // A third party overwrites log
+    const _oldConsole = console.log;
+    const overwrite = (...args: any) => {
+      thirdPartyCall++;
+      return _oldConsole(...args);
+    };
+    console.log = overwrite;
+
+    consoleWatcher.disable();
+    console.log('hello');
+    expect(overwrite).toEqual(console.log);
+    expect(thirdPartyCall).toEqual(1);
+  });
+
+  it('Integrated testing', () => {
+    let thirdPartyCall = 0;
+
+    const FSLog = NativeModules.FullStory.log;
+
+    console.log('goodlog0');
+    expect(FSLog).toBeCalledTimes(1);
+
+    consoleWatcher.disable();
+
+    console.log('goodlog0');
+    expect(FSLog).toBeCalledTimes(1);
+
+    // A third party overwrites log
+    const _oldConsole = console.log;
+    const overwrite = (...args: any) => {
+      thirdPartyCall++;
+      return _oldConsole(...args);
+    };
+    console.log = overwrite;
+
+    consoleWatcher.enable();
+
+    console.log('goodlog0');
+
+    expect(FSLog).toBeCalledTimes(2);
+    expect(thirdPartyCall).toEqual(1);
+
+    consoleWatcher.disable();
+
+    console.log('goodlog0');
+
+    // disable does not replace 3rd party overwrite function
+    expect(overwrite).toEqual(console.log);
+    expect(FSLog).toBeCalledTimes(2);
+    expect(thirdPartyCall).toEqual(2);
+
+    consoleWatcher.enable();
+
+    console.log('goodlog0');
+
+    // reenabling does still calls 3rd party overwrite function
+    expect(FSLog).toBeCalledTimes(3);
+    expect(thirdPartyCall).toEqual(3);
   });
 });

--- a/src/__tests__/safeStringify.test.ts
+++ b/src/__tests__/safeStringify.test.ts
@@ -1,0 +1,174 @@
+import { safeStringify } from '../logging/safeStringify';
+
+const LARGE_MAX_CHARS = 10000; // Arbitrarily large.
+
+const expectValidJSON = (str: string) => expect(() => JSON.parse(str)).not.toThrowError();
+
+describe('safeStringify', () => {
+  it('handles character limits', () => {
+    const a1 = [1, 2, 3, [4, 5, [6, 7, 8], 9], 10];
+
+    {
+      // No truncation
+      const act = safeStringify(a1, LARGE_MAX_CHARS);
+      expect(act).toBe('[1,2,3,[4,5,[6,7,8],9],10]');
+      expectValidJSON(act);
+    }
+
+    {
+      // truncate an array
+      const act = safeStringify(a1, 10);
+      expect(act).toBe('[1,2,3,[]]');
+      expectValidJSON(act);
+    }
+
+    {
+      // truncate on nested array
+      const act = safeStringify(a1, 16);
+      expect(act).toBe('[1,2,3,[4,5,[]]]');
+      expectValidJSON(act);
+    }
+
+    {
+      // truncate really short array (no trailing comma!)
+      const act = safeStringify(a1, 4); // Test for trailing comma
+      expect(act).toBe('[1]');
+      expectValidJSON(act);
+    }
+
+    {
+      // no truncate regular object
+      const o1 = { a: 1, b: 2, c: null, d: undefined, e: 'asdf' };
+      const act = safeStringify(o1, LARGE_MAX_CHARS);
+      expect(act).toBe('{"a":1,"b":2,"c":null,"d":"undefined","e":"asdf"}');
+      expectValidJSON(act);
+    }
+
+    const o2 = { a: 1, b: 2, c: null, d: [1, 2, ['three'], [], {}, []], e: 'asdf' };
+
+    {
+      // truncation on regular object
+      const act = safeStringify(o2, 13);
+      expect(act).toBe('{"a":1,"b":2}');
+      expectValidJSON(act);
+    }
+
+    {
+      // Check we don't include the key when truncating a value
+      const act = safeStringify(o2, 15);
+      expect(act).toBe('{"a":1,"b":2}');
+      expectValidJSON(act);
+    }
+
+    {
+      // truncate nested object
+      const act = safeStringify(o2, 45);
+      expect(act).toBe('{"a":1,"b":2,"c":null,"d":[1,2,["three"],[]]}');
+      expectValidJSON(act);
+    }
+
+    // Truncate strings
+    const longStringWithLineBreaks = `
+It was a dark and stormy night; the rain fell in torrents, except at occasional
+intervals, when it was checked by a violent gust of wind which swept up the
+streets (for it is in London that our scene lies), rattling along the housetops,
+and fiercely agitating the scanty flame of the lamps that struggled against the
+darkness.`;
+
+    {
+      // ellipses on truncated string
+      const act = safeStringify(longStringWithLineBreaks, 20);
+      expect(act).toBe('"\\nIt was a dark..."');
+      expectValidJSON(act);
+    }
+
+    {
+      // ellipses on truncated string in object
+      const act = safeStringify({ openingSentence: longStringWithLineBreaks }, 40);
+      expect(act).toBe('{"openingSentence":"\\nIt was a dark..."}');
+      expectValidJSON(act);
+    }
+
+    // Properly truncate dates
+    const date = new Date(0);
+    expect(safeStringify(date, LARGE_MAX_CHARS)).toBe('"Thu, 01 Jan 1970 00:00:00 GMT"');
+    expect(safeStringify(date, 20)).toBe('"Thu, 01 Jan 197..."');
+  });
+
+  it('handles primitives', () => {
+    expect(safeStringify(true, LARGE_MAX_CHARS)).toBe('true');
+    expect(safeStringify(false, LARGE_MAX_CHARS)).toBe('false');
+    expect(safeStringify(12345, LARGE_MAX_CHARS)).toBe('12345');
+    expect(safeStringify(-12345, LARGE_MAX_CHARS)).toBe('-12345');
+
+    const fn = function asdf() {
+      return 12345;
+    };
+    expect(safeStringify(fn, LARGE_MAX_CHARS)).toBe('');
+    expect(safeStringify([fn, null, 'asdf'], LARGE_MAX_CHARS)).toBe('[null,null,"asdf"]');
+  });
+
+  it('handles stringify log message error', () => {
+    const simpleError = new Error('zoinks!');
+
+    {
+      simpleError['stack'] = undefined; // Pretend stack isn't supported
+      expect(safeStringify(simpleError, LARGE_MAX_CHARS)).toBe('"Error: zoinks!"');
+    }
+
+    {
+      // if stack is available, it should include the name, message, and stack
+      simpleError['stack'] = 'Scooby-Doo - where are you?';
+      expect(safeStringify(simpleError, LARGE_MAX_CHARS)).toBe(
+        '"Error: zoinks!,Scooby-Doo - where are you?"',
+      );
+    }
+
+    {
+      // Pretend stack IS supported (and its format predictable)
+      // but if name and message are empty, only stack should be returned
+      simpleError['stack'] = 'Scooby-Doo - where are you?';
+      simpleError['name'] = '';
+      simpleError['message'] = '';
+      // Earlier versions of FF still show "Error" in toString even if you've randomly nulled out
+      // "name" and "message". Let's capture that here.
+      expect(safeStringify(simpleError, LARGE_MAX_CHARS)).toBe(
+        simpleError.toString()
+          ? '"Error,Scooby-Doo - where are you?"' // <- Firefox <= 33
+          : '"Scooby-Doo - where are you?"', // <- everyone else 🤷
+      );
+    }
+
+    const specificError = new TypeError('jinkies!');
+    specificError['stack'] = undefined;
+    expect(safeStringify(specificError, LARGE_MAX_CHARS)).toBe('"TypeError: jinkies!"');
+  });
+
+  it('handles stringify log message cycle detection', () => {
+    {
+      // Cyclical array
+      const arr: any[] = [];
+      arr.push(arr);
+      const act = safeStringify(arr, LARGE_MAX_CHARS);
+      expect(act).toBe('["<Cycle to ancestor #0>"]');
+      expectValidJSON(act);
+    }
+
+    {
+      // Cyclical Object
+      const cycle: any = { a: null };
+      cycle.a = cycle;
+      const act = safeStringify(cycle, LARGE_MAX_CHARS);
+      expect(act).toBe('{"a":"<Cycle to ancestor #0>"}');
+      expectValidJSON(act);
+    }
+
+    {
+      // Deeply nested cyclical object
+      const deeper = { a: { b: { c: { d: {} } } } };
+      deeper.a.b.c.d = deeper.a.b;
+      const act = safeStringify(deeper, LARGE_MAX_CHARS);
+      expect(act).toBe('{"a":{"b":{"c":{"d":"<Cycle to ancestor #1>"}}}}');
+    }
+  });
+});

--- a/src/consoleCapture.ts
+++ b/src/consoleCapture.ts
@@ -1,0 +1,46 @@
+import { NativeModules } from 'react-native';
+
+// @ts-expect-error
+const isTurboModuleEnabled = global.__turboModuleProxy != null;
+
+const FullStory = isTurboModuleEnabled
+  ? require('./NativeFullStory').default
+  : NativeModules.FullStory;
+
+export enum LogLevel {
+  Log = 0, // Clamps to Debug on iOS
+  Debug = 1,
+  Info = 2, // Default
+  Warn = 3,
+  Error = 4,
+  Assert = 5, // Clamps to Error on Android
+}
+
+const consoleLevelMap = {
+  log: LogLevel.Log,
+  trace: LogLevel.Debug,
+  debug: LogLevel.Debug,
+  info: LogLevel.Info,
+  warn: LogLevel.Warn,
+  error: LogLevel.Error,
+};
+
+export const enableConsoleCapture = () => {
+  type ConsoleLevels = keyof typeof consoleLevelMap;
+
+  for (const rnLogLevel in consoleLevelMap) {
+    if (!(rnLogLevel in console)) {
+      continue;
+    }
+
+    const originalLogger = console[rnLogLevel as ConsoleLevels];
+
+    console[rnLogLevel as ConsoleLevels] = function (message?: any, ...args: any[]) {
+      // call FS log with the mapped level
+      FullStory.log(consoleLevelMap[rnLogLevel as ConsoleLevels], [message, ...args].join(' '));
+
+      // call original logger
+      originalLogger.apply(console, [message, ...args]);
+    };
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { HostComponent, NativeModules, Platform } from 'react-native';
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import { ForwardedRef } from 'react';
-import { LogLevel, enableConsoleCapture } from './consoleCapture';
+import { LogLevel, enableConsoleCapture } from './logging/consoleCapture';
 
 // @ts-expect-error
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
@@ -61,7 +61,7 @@ declare type FullStoryStatic = {
   restart(): void;
   log(logLevel: LogLevel, message: string): void;
   resetIdleTimer(): void;
-  enableConsoleCapture(logLevel: LogLevel): void;
+  enableConsoleCapture(): void;
 };
 
 declare global {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropT
 import { ForwardedRef } from 'react';
 import consoleWatcher, { LogLevel } from './logging/consoleCapture';
 
-// @ts-expect-error
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
 interface NativeProps extends ViewProps {
@@ -73,6 +72,9 @@ declare global {
       fsTagName?: string;
     }
   }
+  const global: typeof globalThis & {
+    __turboModuleProxy: unknown;
+  };
 }
 
 const identifyWithProperties = (uid: string, userVars = {}) => identify(uid, userVars);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { HostComponent, NativeModules, Platform } from 'react-native';
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import { ForwardedRef } from 'react';
-import { LogLevel, enableConsoleCapture } from './logging/consoleCapture';
+import consoleWatcher, { LogLevel } from './logging/consoleCapture';
 
 // @ts-expect-error
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
@@ -61,7 +61,8 @@ declare type FullStoryStatic = {
   restart(): void;
   log(logLevel: LogLevel, message: string): void;
   resetIdleTimer(): void;
-  enableConsoleCapture(): void;
+  enableConsole(): void;
+  disableConsole(): void;
 };
 
 declare global {
@@ -155,6 +156,9 @@ export function applyFSPropertiesWithRef(existingRef?: ForwardedRef<unknown>) {
 export { LogLevel };
 export { FSPage } from './FSPage';
 
+// default ON
+consoleWatcher.enable();
+
 const FullStoryAPI: FullStoryStatic = {
   anonymize,
   identify: identifyWithProperties,
@@ -169,7 +173,8 @@ const FullStoryAPI: FullStoryStatic = {
   log,
   resetIdleTimer,
   LogLevel,
-  enableConsoleCapture,
+  enableConsole: consoleWatcher.enable,
+  disableConsole: consoleWatcher.disable,
 };
 
 export default FullStoryAPI;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,7 @@ import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativ
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import { ForwardedRef } from 'react';
 import consoleWatcher, { LogLevel } from './logging/consoleCapture';
-
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+import { isTurboModuleEnabled } from './utils';
 
 interface NativeProps extends ViewProps {
   fsClass?: string;
@@ -72,9 +71,6 @@ declare global {
       fsTagName?: string;
     }
   }
-  const global: typeof globalThis & {
-    __turboModuleProxy: unknown;
-  };
 }
 
 const identifyWithProperties = (uid: string, userVars = {}) => identify(uid, userVars);

--- a/src/logging/consoleCapture.ts
+++ b/src/logging/consoleCapture.ts
@@ -1,7 +1,6 @@
 import { NativeModules } from 'react-native';
 import { safeStringify } from './safeStringify';
 
-// @ts-expect-error
 const isTurboModuleEnabled = global.__turboModuleProxy != null;
 
 const FullStory = isTurboModuleEnabled
@@ -30,7 +29,7 @@ type ConsoleLevels = keyof typeof consoleLevelMap;
 type MethodShim = Record<'native' | 'override', Function>;
 
 type ConsoleShims = {
-  [K in keyof typeof consoleLevelMap]?: MethodShim | null;
+  [key in ConsoleLevels]?: MethodShim;
 };
 
 const logEvent = (level: LogLevel, args: ArrayLike<unknown>) => {
@@ -43,8 +42,6 @@ const logEvent = (level: LogLevel, args: ArrayLike<unknown>) => {
   FullStory.log(level, payload.join(' '));
 };
 
-// A naive version of ConsoleWatcher on web.
-// See https://github.com/cowpaths/mn/blob/865353f374b687e481d3b230e7eec8e1d7be2eb4/projects/fullstory/packages/recording/src/consolewatcher.ts
 class ConsoleWatcher {
   private _isActive = false;
   private _shims: ConsoleShims = {};
@@ -59,44 +56,51 @@ class ConsoleWatcher {
   }
 
   disable() {
-    if (this._isActive) {
-      this._isActive = false;
-      for (const logLevel in this._shims as ConsoleShims) {
-        if (!this._shims[logLevel as ConsoleLevels]) {
-          return;
-        }
+    if (!this._isActive) {
+      return;
+    }
 
-        // If possible, restore the original logger function
-        const { override, native } = this._shims[logLevel as ConsoleLevels] as MethodShim;
-        // If our override has not been replaced by a 3rd party, revert back to native function
-        if (console[logLevel as ConsoleLevels] === override) {
-          console[logLevel as ConsoleLevels] = native as any;
-          this._shims[logLevel as ConsoleLevels] = undefined;
-        }
+    this._isActive = false;
+    let logLevel: ConsoleLevels;
+    for (logLevel in this._shims) {
+      if (!this._shims[logLevel]) {
+        return;
+      }
+
+      // If possible, restore the original logger function
+      const { override, native } = this._shims[logLevel] as MethodShim;
+      // If our override has not been replaced by a 3rd party, revert back to native function
+      if (console[logLevel] === override) {
+        console[logLevel] = native as any;
+        this._shims[logLevel] = undefined;
       }
     }
   }
 
   private _makeShim() {
-    for (const rnLogLevel in consoleLevelMap) {
+    let rnLogLevel: ConsoleLevels;
+    for (rnLogLevel in consoleLevelMap) {
+      // copied by value for override func
+      const _rnLogLevel = rnLogLevel;
+
       if (!(rnLogLevel in console)) {
         continue;
       }
 
-      const originalLogger = console[rnLogLevel as ConsoleLevels];
+      const originalLogger = console[rnLogLevel];
 
       const override = (...args: any[]) => {
         // call FS log with the mapped level
         if (this._isActive) {
-          logEvent(consoleLevelMap[rnLogLevel as ConsoleLevels], args);
+          logEvent(consoleLevelMap[_rnLogLevel], args);
         }
 
         // call original logger
-        originalLogger.apply(console, [...args]);
+        originalLogger.apply(console, args);
       };
 
-      console[rnLogLevel as ConsoleLevels] = override;
-      this._shims[rnLogLevel as ConsoleLevels] = { override, native: originalLogger };
+      console[rnLogLevel] = override;
+      this._shims[rnLogLevel] = { override, native: originalLogger };
     }
   }
 }

--- a/src/logging/consoleCapture.ts
+++ b/src/logging/consoleCapture.ts
@@ -1,7 +1,6 @@
 import { NativeModules } from 'react-native';
 import { safeStringify } from './safeStringify';
-
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+import { isTurboModuleEnabled } from '../utils';
 
 const FullStory = isTurboModuleEnabled
   ? require('../NativeFullStory').default

--- a/src/logging/safeStringify.ts
+++ b/src/logging/safeStringify.ts
@@ -1,0 +1,196 @@
+/** jsonErrorString returns a valid JSON string representation of the error. */
+function jsonErrorString(e: Error): string {
+  let errorString = 'Internal error: unable to determine what JSON error was';
+  try {
+    errorString = `${e}`;
+    // Sanitize the error: alphanumeric and some punctuation only, be paranoid here
+    errorString = errorString.replace(/[^a-zA-Z0-9.:!, ]/g, '_');
+  } catch (e2) {
+    // Give up, use the unknown one
+  }
+  return `"${errorString}"`;
+}
+
+interface StringifyContext {
+  tokens: string[];
+  opath: any[];
+  cyclic: boolean;
+}
+
+/**
+ * safeStringify
+ *
+ * safeStringify is defined to NEVER BE ABLE TO THROW. It is meant to stringify
+ * unstructured data containing a mix of objects, strings, and primitives like in
+ * console log arguments. It must return a string that can be validly JSON.parsed() by
+ * our playback client. It tries it's best to mirror what console.log() would print
+ * in the JS console.
+ */
+export function safeStringify(o: any, maxChars: number = 1024): string {
+  try {
+    const state: StringifyContext = {
+      tokens: [],
+      opath: [],
+      cyclic: isCyclic(o, maxChars / 4),
+    };
+    stringifyAux(o, maxChars, 0, state);
+    return state.tokens.join('');
+  } catch (e) {
+    return jsonErrorString(e as unknown as Error);
+  }
+}
+
+// NOTE: May return false negative, since search is limited
+// Assumed to be called *after* getRealJSONObject
+function isCyclic(o: any, maxProps: number): boolean {
+  let count = 0;
+  try {
+    JSON.stringify(o, (_key, value) => {
+      if (count++ > maxProps) throw 'break';
+      if (typeof value !== 'object') return undefined;
+      return value;
+    });
+  } catch (e) {
+    if (e === 'break') return false;
+    // No cycle detected before limit reached
+    else return true;
+  }
+  return false;
+}
+
+const dateString = (x: Date) => (isNaN(x as any) ? 'Invalid Date' : x.toUTCString());
+const truncate = (s: string, len: number, end = '...') => {
+  if (s.length <= len) return s;
+  if (s.length <= end.length || len <= end.length) return s.substring(0, len);
+  return s.substring(0, len - end.length) + end;
+};
+
+// Returns the number of characters in the stringified result
+function stringifyAux(o: any, maxChars: number, depth: number, ctx: StringifyContext): number {
+  if (maxChars < 1) return 0;
+
+  /**
+   * 1. Base cases: primitives and special cases like dates
+   *
+   *    - Strings and primitives like true, false, null become valid JSON
+   *    - undefined becomes JSON.stringify('undefined') => '"undefined"'
+   *    - non objects like functions and symbols get ignored
+   *    - Arrays and Objects are sent along to the next steps.
+   */
+  const replacement = getStringReplacement(o);
+
+  if (replacement !== undefined) {
+    // Convert to string or quote/escape string
+    const token = primitiveToJSONString(replacement, maxChars);
+    if (typeof token === 'string' && token.length <= maxChars) {
+      ctx.tokens.push(token);
+      return token.length;
+    } else {
+      return 0;
+    }
+  }
+
+  /**
+   * 2. Cycles
+   *
+   *    If an object is determined to be a cyclical reference, we replace it with a
+   *    special string:
+   *
+   *    `<Cycle to ancestor #X>`
+   */
+  if (ctx.cyclic) {
+    ctx.opath.splice(depth);
+    const previousDepth = ctx.opath.lastIndexOf(o);
+    if (previousDepth > -1) {
+      let s = `<Cycle to ancestor #${depth - previousDepth - 1}>`;
+      s = `"${truncate(s, maxChars - 2)}"`;
+      ctx.tokens.push(s);
+      return s.length;
+    }
+    ctx.opath.push(o);
+  }
+
+  /**
+   * 3. Recursive cases
+   *
+   *    We recursively parse arrays and objects pushing each piece
+   *    into ctx.tokens to be `.join('')`'d for the end result later.
+   */
+
+  let charsRemaining = maxChars;
+  const pushToken = (s: string): boolean => {
+    if (charsRemaining >= s.length) {
+      charsRemaining -= s.length;
+      ctx.tokens.push(s);
+      return true;
+    }
+    return false;
+  };
+
+  const overwriteTrailingComma = (s: string) => {
+    // s should always be a single character
+    const last = ctx.tokens.length - 1;
+    if (ctx.tokens[last] === ',') {
+      ctx.tokens[last] = s;
+    } else {
+      pushToken(s);
+    }
+  };
+  if (charsRemaining < 2) return 0; // Ensure space for closing } or ]
+
+  if (Array.isArray(o)) {
+    pushToken('[');
+    for (let i = 0; i < o.length && charsRemaining > 0; i++) {
+      const n = stringifyAux(o[i], charsRemaining - 1, depth + 1, ctx);
+      charsRemaining -= n;
+      if (n === 0 && !pushToken('null')) break;
+      pushToken(',');
+    }
+    overwriteTrailingComma(']');
+  } else {
+    pushToken('{');
+    const oKeys = Object.keys(o);
+    for (let i = 0; i < oKeys.length && charsRemaining > 0; i++) {
+      const key = oKeys[i];
+      const value = o[key];
+      if (!pushToken(`"${key}":`)) break;
+      const n = stringifyAux(value, charsRemaining - 1, depth + 1, ctx);
+      if (n === 0) {
+        ctx.tokens.pop(); // Don't insert a trailing key
+        break;
+      }
+      charsRemaining -= n;
+      pushToken(',');
+    }
+    overwriteTrailingComma('}');
+  }
+
+  return maxChars === Infinity ? 1 : maxChars - charsRemaining;
+}
+
+function getStringReplacement(o: any): string | undefined {
+  switch (true) {
+    case isDate(o):
+      return dateString(o);
+    case o === undefined:
+      return 'undefined';
+    case typeof o !== 'object' || o == null:
+      return o;
+    case o instanceof Error:
+      return [o.toString(), o.stack].filter(Boolean).join(',');
+  }
+  return undefined;
+}
+
+function primitiveToJSONString(s: string, maxChars: number): string | void {
+  // Convert to string or quote/escape string
+  const token = JSON.stringify(s);
+  if (token && token[0] === '"') {
+    return truncate(token, maxChars, '..."');
+  }
+  return token;
+}
+
+function isDate(o: any): boolean {
+  return !!(o && o.constructor === Date);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,3 +51,7 @@ export const generateUUID = (function () {
 
   return f;
 })();
+
+declare const global: typeof globalThis & { __turboModuleProxy: unknown };
+
+export const isTurboModuleEnabled = global.__turboModuleProxy != null;


### PR DESCRIPTION
Issue: https://fullstory.atlassian.net/browse/MOCA-8076

Add methods `enableConsole ` and `disableConsole` to FullStory API that will extend React Native's `console` API. Messages will be passed to `FS.log`. 

Console capture defaults to enabled, and follows the FS default log level of `info` if the customer hasn't configured it already.

Example session: https://app.staging.fullstory.com/ui/KWH/session/6727898337050624:5966357937455104/devtools/console

Added enable and disable API.

Added `safeStringify` from web side, minus `DOM` node handling since that's not defined in RN.