### PR TITLE
release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.1
+
+Updated the minimum version for the FullStory `@fullstory/babel-plugin-react-native` babel plugin to `1.1.0` for New Architecture support.
+
 ## 1.4.0
 
 Added support for the [React Native New Architecture](https://reactnative.dev/docs/the-new-architecture/landing-page) (this includes support for Fabric and Turbo Native Modules). Refer to the [New Architecture](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-FullStory-React-Native-Capture#01HHCXMMZQ970DRWFA0XC03ER4) section of the FullStory React Native Getting Started guide for more information about minimum SDK and plugin versions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/react-native",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The official FullStory React Native plugin",
   "repository": "git://github.com/fullstorydev/fullstory-react-native.git",
   "homepage": "https://github.com/fullstorydev/fullstory-react-native",


### PR DESCRIPTION
`1.4.0`'s [release](https://github.com/fullstorydev/fullstory-react-native/pull/81/files) did not include a dependency update made to `@fullstory/babel-plugin-react-native`, since that update was made in the same PR as the release. 