### PR TITLE
Raise audit level to pass CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
       - run:
           name: Audit
-          command: npm audit --audit-level=low
+          command: npm audit --audit-level=critical
       - run:
           name: Lint
           command: npm run lint


### PR DESCRIPTION
Dependency [react-native-cli](https://github.com/react-native-community/cli/issues/2294) `ip` received a security warning which the community is in the process of resolving. We're raising the audit level here to prevent us from being blocked from making updates.