### PR TITLE
RNN selector support

### DIFF
--- a/ios/FullStory.mm
+++ b/ios/FullStory.mm
@@ -384,7 +384,7 @@ static bool array_contains_string(const char **array, const char *string) {
         if ([self respondsToSelector:@selector(layoutInfo)]) {
             id layoutInfo = [self performSelector:@selector(layoutInfo)];
             if ([layoutInfo respondsToSelector:@selector(name)]) {
-                set_fsAttribute(@{@"screen-name": [[self performSelector:NSSelectorFromString(@"layoutInfo")] name]}, (RCTView *)viewController.view);
+                set_fsAttribute(@{@"screen-name": [layoutInfo name]}, (RCTView *)viewController.view);
             }
         } else {
             NSLog(@"RNNComponentViewController cannot communicate screen names to FullStory. Navigation events and screen selectors may not function correctly.");

--- a/ios/FullStory.mm
+++ b/ios/FullStory.mm
@@ -372,6 +372,26 @@ static bool array_contains_string(const char **array, const char *string) {
     SWIZZLE_HANDLE_COMMAND(RCTPullToRefreshViewComponentView);
     SWIZZLE_HANDLE_COMMAND(RCTLegacyViewManagerInteropComponentView);
 #pragma clang pop
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+    SWIZZLE_BEGIN_INSTANCE(RNNComponentViewController, @selector(renderReactViewIfNeeded), void) {
+        SWIZZLED_METHOD();
+        
+        UIViewController *viewController = self;
+        
+        if ([self respondsToSelector:@selector(layoutInfo)]) {
+            id layoutInfo = [self performSelector:@selector(layoutInfo)];
+            if ([layoutInfo respondsToSelector:@selector(name)]) {
+                set_fsAttribute(@{@"screen-name": [[self performSelector:NSSelectorFromString(@"layoutInfo")] name]}, (RCTView *)viewController.view);
+            }
+        } else {
+            NSLog(@"RNNComponentViewController cannot communicate screen names to FullStory. Navigation events and screen selectors may not function correctly.");
+        }
+    } SWIZZLE_END;
+#pragma clang pop
+
 #if defined(DEBUG_FS_RN_FABRIC_THIRD_PARTY) && defined(DEBUG)
     // RCTViewComponentView subclasses don't tend to call their superclass
     // implementations of handleCommand, so in debug mode, we want to make sure


### PR DESCRIPTION
To support React Native Navigation screen selectors, we'll need to assign the screen name value from `layoutInfo.name` to fsAttributes, where we'll read it from the SDK.

Paired with [PR](https://github.com/cowpaths/mn/pull/74866)