### PR TITLE
support RN 74 on iOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@react-native/eslint-plugin-specs": "^0.72.4",
         "@tsconfig/node10": "^1.0.9",
         "@types/jest": "^28.1.4",
-        "@types/react": "^18.2.21",
+        "@types/react": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.4.0",
         "babel-jest": "^29.6.4",
@@ -6865,21 +6865,14 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.21",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
-      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@react-native/eslint-plugin-specs": "^0.72.4",
     "@tsconfig/node10": "^1.0.9",
     "@types/jest": "^28.1.4",
-    "@types/react": "^18.2.21",
+    "@types/react": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.4.0",
     "babel-jest": "^29.6.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,38 +115,50 @@ const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
 
 export function applyFSPropertiesWithRef(existingRef?: ForwardedRef<unknown>) {
   return function (element: React.ElementRef<FSComponentType>) {
-    // https://github.com/facebook/react-native/blob/87d2ea9c364c7ea393d11718c195dfe580c916ef/packages/react-native/Libraries/Components/TextInput/TextInputState.js#L109C23-L109C67
-    // @ts-expect-error `currentProps` is missing in `NativeMethods`
-    const currentProps = element?.currentProps as Record<keyof NativeCommands, string | object>;
-    if (isTurboModuleEnabled && Platform.OS === 'ios' && currentProps) {
-      const fsClass = currentProps.fsClass as string;
-      if (fsClass) {
-        Commands.fsClass(element, fsClass);
-      }
+    if (isTurboModuleEnabled && Platform.OS === 'ios') {
+      let currentProps: Record<keyof NativeCommands, string | object>;
 
-      const fsAttribute = currentProps.fsAttribute as object;
-      if (fsAttribute) {
-        Commands.fsAttribute(element, fsAttribute);
-      }
+      const getInternalInstanceHandleFromPublicInstance =
+        require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance').getInternalInstanceHandleFromPublicInstance;
 
-      const fsTagName = currentProps.fsTagName as string;
-      if (fsTagName) {
-        Commands.fsTagName(element, fsTagName);
+      if (getInternalInstanceHandleFromPublicInstance && element) {
+        currentProps =
+          getInternalInstanceHandleFromPublicInstance(element)?.stateNode?.canonical.currentProps;
+      } else {
+        // https://github.com/facebook/react-native/blob/87d2ea9c364c7ea393d11718c195dfe580c916ef/packages/react-native/Libraries/Components/TextInput/TextInputState.js#L109C23-L109C67
+        // @ts-expect-error `currentProps` is missing in `NativeMethods`
+        currentProps = element?.currentProps;
       }
+      if (currentProps) {
+        const fsClass = currentProps.fsClass as string;
+        if (fsClass) {
+          Commands.fsClass(element, fsClass);
+        }
 
-      const dataElement = currentProps.dataElement as string;
-      if (dataElement) {
-        Commands.dataElement(element, dataElement);
-      }
+        const fsAttribute = currentProps.fsAttribute as object;
+        if (fsAttribute) {
+          Commands.fsAttribute(element, fsAttribute);
+        }
 
-      const dataComponent = currentProps.dataComponent as string;
-      if (dataComponent) {
-        Commands.dataComponent(element, dataComponent);
-      }
+        const fsTagName = currentProps.fsTagName as string;
+        if (fsTagName) {
+          Commands.fsTagName(element, fsTagName);
+        }
 
-      const dataSourceFile = currentProps.dataSourceFile as string;
-      if (dataSourceFile) {
-        Commands.dataSourceFile(element, dataSourceFile);
+        const dataElement = currentProps.dataElement as string;
+        if (dataElement) {
+          Commands.dataElement(element, dataElement);
+        }
+
+        const dataComponent = currentProps.dataComponent as string;
+        if (dataComponent) {
+          Commands.dataComponent(element, dataComponent);
+        }
+
+        const dataSourceFile = currentProps.dataSourceFile as string;
+        if (dataSourceFile) {
+          Commands.dataSourceFile(element, dataSourceFile);
+        }
       }
     }
 


### PR DESCRIPTION
React `18.3.0` moved the `currentProps` object into the `canonical` property. [PR here](https://github.com/facebook/react/pull/26408).

This is causing us to not be able to read our FS attributes off of the component instance. 

RN `0.74.0` has a new function ([PR here](https://github.com/facebook/react-native/pull/41786)) called `getInternalInstanceHandleFromPublicInstance` that will help us get at the `currentProps` property. If `getInternalInstanceHandleFromPublicInstance` exists, we'll try to use it as it's indicative of the new Fabric Component Tree.