### PR TITLE
update the RN plugin to receive clicks from JS

### DIFF
--- a/android/src/legacy/java/com/FullStoryPrivateModule.java
+++ b/android/src/legacy/java/com/FullStoryPrivateModule.java
@@ -1,0 +1,23 @@
+package com.fullstory.reactnative;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+public class FullStoryPrivateModule extends ReactContextBaseJavaModule {
+    private final ReactApplicationContext context;
+    FullStoryPrivateModule(ReactApplicationContext context) {
+        super(context);
+        this.context = context;
+    }
+
+    @Override
+    public String getName() {
+        return FullStoryPrivateModuleImpl.NAME;
+    }
+
+    @ReactMethod
+    public void onFSPressForward(final double tag, final boolean isLongPress, final boolean hasPressHandler, final boolean hasLongPressHandler) {
+        FullStoryPrivateModuleImpl.onFSPressForward(context, tag, isLongPress, hasPressHandler, hasLongPressHandler);
+    }
+}

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryPackage.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryPackage.java
@@ -18,6 +18,8 @@ public class FullStoryPackage extends TurboReactPackage implements ReactPackage 
     public NativeModule getModule(String name, ReactApplicationContext reactContext) {
         if (FullStoryModuleImpl.NAME.equals(name)) {
             return new FullStoryModule(reactContext);
+        } else if (FullStoryPrivateModuleImpl.NAME.equals(name)) {
+            return new FullStoryPrivateModule(reactContext);
         } else {
             return null;
         }
@@ -32,6 +34,17 @@ public class FullStoryPackage extends TurboReactPackage implements ReactPackage 
                 new ReactModuleInfo(
                         FullStoryModuleImpl.NAME,
                         FullStoryModuleImpl.NAME,
+                        false, // canOverrideExistingModule
+                        false, // needsEagerInit
+                        true, // hasConstants
+                        false, // isCxxModule
+                        isTurboModule // isTurboModule
+        ));
+        moduleInfos.put(
+                FullStoryPrivateModuleImpl.NAME,
+                new ReactModuleInfo(
+                        FullStoryPrivateModuleImpl.NAME,
+                        FullStoryPrivateModuleImpl.NAME,
                         false, // canOverrideExistingModule
                         false, // needsEagerInit
                         true, // hasConstants

--- a/android/src/main/java/com/fullstory/reactnative/FullStoryPrivateModuleImpl.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryPrivateModuleImpl.java
@@ -1,0 +1,71 @@
+package com.fullstory.reactnative;
+
+import android.util.Log;
+import android.view.View;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.UIManager;
+import com.facebook.react.uimanager.UIManagerHelper;
+import com.facebook.react.uimanager.common.ViewUtil;
+import com.fullstory.FS;
+
+import java.lang.reflect.Method;
+
+public class FullStoryPrivateModuleImpl {
+
+    public static final String NAME = "FullStoryPrivate";
+    private static final String TAG = "FullStoryPrivateModuleImpl";
+
+    public static final boolean clickReflectionSuccess;
+    private static final Method CLICK_HANDLER;
+
+    static {
+        Method clickHandler;
+
+        try {
+            clickHandler = FS.class.getMethod("reactNative_exec_onFsPressForward_direct", View.class, boolean.class, boolean.class, boolean.class);
+        } catch (Throwable t) {
+            clickHandler = null;
+            Log.e(TAG, "Unable to access native FullStory click handler API. Click events for React Native 74+ will not function correctly. " +
+                    "Make sure that your plugin is at least version 1.49; if the issue persists, please contact FullStory Support.");
+        }
+
+        CLICK_HANDLER = clickHandler;
+
+        clickReflectionSuccess = CLICK_HANDLER != null;
+    }
+
+    public static void onFSPressForward(final ReactApplicationContext context, final double tag, final boolean isLongPress, final boolean hasPressHandler, final boolean hasLongPressHandler) {
+        if (!clickReflectionSuccess) {
+            return;
+        }
+
+        // This will throw if the view cannot be resolved, so try/catch it.
+        View view = null;
+        try {
+            int reactTag = (int) tag;
+            if (reactTag == -1) {
+                return;
+            }
+            UIManager uiManager = UIManagerHelper.getUIManager(context, ViewUtil.getUIManagerType(reactTag));
+            if (uiManager == null) {
+                return;
+            }
+            view = uiManager.resolveView(reactTag);
+        } catch (Throwable t) {
+            // Silently ignore.
+            return;
+        }
+        
+        if (view == null) {
+            return;
+        }
+
+        try {
+            CLICK_HANDLER.invoke(null, view, isLongPress, hasPressHandler, hasLongPressHandler);
+        } catch (Throwable t) {
+            // This should never happen, so log the error.
+            Log.e(TAG, "Unexpected error while calling the click handler. Please contact FullStory Support.");
+        }
+    }
+}

--- a/android/src/turbo/java/com/FullStoryPrivateModule.java
+++ b/android/src/turbo/java/com/FullStoryPrivateModule.java
@@ -1,0 +1,24 @@
+package com.fullstory.reactnative;
+
+import androidx.annotation.NonNull;
+import com.facebook.react.bridge.ReactApplicationContext;
+
+public class FullStoryPrivateModule extends NativeFullStoryPrivateSpec {
+
+    private final ReactApplicationContext context;
+    FullStoryPrivateModule(ReactApplicationContext context) {
+        super(context);
+        this.context = context;
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return FullStoryPrivateModuleImpl.NAME;
+    }
+
+    @Override
+    public void onFSPressForward(final double tag, final boolean isLongPress, final boolean hasPressHandler, final boolean hasLongPressHandler) {
+        FullStoryPrivateModuleImpl.onFSPressForward(context, tag, isLongPress, hasPressHandler, hasLongPressHandler);
+    }
+}

--- a/ios/FullStory.h
+++ b/ios/FullStory.h
@@ -9,6 +9,9 @@
 @interface FullStory : NSObject <RCTBridgeModule, FSDelegate>
 @end
 
+@interface FullStoryPrivate : NSObject <RCTBridgeModule, FSDelegate>
+@end
+
 @interface FS(FSPrivate)
 + (void) _pageViewWithNonce:(NSUUID *)nonce name:(NSString *)pageName properties:(NSDictionary<NSString *, id> *)properties;
 + (void) _updatePageWithNonce:(NSUUID *)nonce properties:(NSDictionary<NSString *, id> *)properties;
@@ -17,5 +20,8 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 @interface FullStory () <NativeFullStorySpec>
+@end
+
+@interface FullStoryPrivate () <NativeFullStoryPrivateSpec>
 @end
 #endif

--- a/ios/FullStory.mm
+++ b/ios/FullStory.mm
@@ -214,6 +214,19 @@ RCT_REMAP_METHOD(onReady, onReadyWithResolver:(RCTPromiseResolveBlock)resolve re
 #endif
 @end
 
+@implementation FullStoryPrivate {}
+
+RCT_EXPORT_MODULE()
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeFullStoryPrivateSpecJSI>(params);
+}
+#endif
+@end
+
 static const char *_rctview_previous_attributes_key = "associated_object_rctview_previous_attributes_key";
 
 static void set_fsClass(id json, RCTView *view) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fullstory/babel-plugin-annotate-react": "^2.2.0",
-    "@fullstory/babel-plugin-react-native": "^1.2.0"
+    "@fullstory/babel-plugin-react-native": "^1.3.0"
   },
   "peerDependencies": {
     "expo": ">=47.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "expo": ">=47.0.0",
     "react": "*",
-    "react-native": ">=0.61.0"
+    "react-native": ">=0.66.0"
   },
   "peerDependenciesMeta": {
     "expo": {

--- a/src/NativeFullStoryPrivate.ts
+++ b/src/NativeFullStoryPrivate.ts
@@ -2,7 +2,12 @@ import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
-  onFSPressForward(tag: number, isLongPress: boolean, hasPressHandler: boolean, hasLongPressHandler: boolean): void;
+  onFSPressForward(
+    tag: number,
+    isLongPress: boolean,
+    hasPressHandler: boolean,
+    hasLongPressHandler: boolean,
+  ): void;
 }
 
 export default TurboModuleRegistry.get<Spec>('FullStoryPrivate');

--- a/src/NativeFullStoryPrivate.ts
+++ b/src/NativeFullStoryPrivate.ts
@@ -1,0 +1,8 @@
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+export interface Spec extends TurboModule {
+  onFSPressForward(tag: number, isLongPress: boolean, hasPressHandler: boolean, hasLongPressHandler: boolean): void;
+}
+
+export default TurboModuleRegistry.get<Spec>('FullStoryPrivate');

--- a/src/NativeFullStoryPrivate.ts
+++ b/src/NativeFullStoryPrivate.ts
@@ -2,7 +2,8 @@ import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
-  onFSPressForward(
+  // Android-only.
+  onFSPressForward?(
     tag: number,
     isLongPress: boolean,
     hasPressHandler: boolean,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,7 @@ const FullStoryPrivate = isTurboModuleEnabled
   ? require('./NativeFullStoryPrivate').default
   : NativeModules.FullStoryPrivate;
 
-const {
-    onFSPressForward,
-  } = FullStoryPrivate;
+const { onFSPressForward } = FullStoryPrivate;
 
 export enum LogLevel {
   Log = 0, // Clamps to Debug on iOS
@@ -80,7 +78,12 @@ declare type FullStoryStatic = {
 };
 
 declare type FullStoryPrivateStatic = {
-  onFSPressForward(tag: number, isLongPress: boolean, hasPressHandler: boolean, hasLongPressHandler: boolean): void;
+  onFSPressForward(
+    tag: number,
+    isLongPress: boolean,
+    hasPressHandler: boolean,
+    hasLongPressHandler: boolean,
+  ): void;
 };
 
 declare global {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,14 @@ const {
   resetIdleTimer,
 } = FullStory;
 
+const FullStoryPrivate = isTurboModuleEnabled
+  ? require('./NativeFullStoryPrivate').default
+  : NativeModules.FullStoryPrivate;
+
+const {
+    onFSPressForward,
+  } = FullStoryPrivate;
+
 export enum LogLevel {
   Log = 0, // Clamps to Debug on iOS
   Debug = 1,
@@ -69,6 +77,10 @@ declare type FullStoryStatic = {
   restart(): void;
   log(logLevel: LogLevel, message: string): void;
   resetIdleTimer(): void;
+};
+
+declare type FullStoryPrivateStatic = {
+  onFSPressForward(tag: number, isLongPress: boolean, hasPressHandler: boolean, hasLongPressHandler: boolean): void;
 };
 
 declare global {
@@ -190,6 +202,10 @@ const FullStoryAPI: FullStoryStatic = {
   log,
   resetIdleTimer,
   LogLevel,
+};
+
+export const FullStoryPrivateAPI: FullStoryPrivateStatic = {
+  onFSPressForward,
 };
 
 export default FullStoryAPI;

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,7 @@ const FullStoryAPI: FullStoryStatic = {
   LogLevel,
 };
 
-export const PrivateInterface: FullStoryPrivateStatic = Platform.OS === 'android' ? { onFSPressForward } : {};
+export const PrivateInterface: FullStoryPrivateStatic =
+  Platform.OS === 'android' ? { onFSPressForward } : {};
 
 export default FullStoryAPI;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,6 @@ const FullStoryPrivate = isTurboModuleEnabled
   ? require('./NativeFullStoryPrivate').default
   : NativeModules.FullStoryPrivate;
 
-const { onFSPressForward } = FullStoryPrivate;
-
 export enum LogLevel {
   Log = 0, // Clamps to Debug on iOS
   Debug = 1,
@@ -208,6 +206,6 @@ const FullStoryAPI: FullStoryStatic = {
 };
 
 export const PrivateInterface: FullStoryPrivateStatic =
-  Platform.OS === 'android' ? { onFSPressForward } : {};
+  Platform.OS === 'android' ? { onFSPressForward: FullStoryPrivate.onFSPressForward } : {};
 
 export default FullStoryAPI;

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ declare type FullStoryStatic = {
 };
 
 declare type FullStoryPrivateStatic = {
-  onFSPressForward(
+  onFSPressForward?(
     tag: number,
     isLongPress: boolean,
     hasPressHandler: boolean,
@@ -207,8 +207,6 @@ const FullStoryAPI: FullStoryStatic = {
   LogLevel,
 };
 
-export const FullStoryPrivateAPI: FullStoryPrivateStatic = {
-  onFSPressForward,
-};
+export const PrivateInterface: FullStoryPrivateStatic = Platform.OS === 'android' ? { onFSPressForward } : {};
 
 export default FullStoryAPI;


### PR DESCRIPTION
This PR adds a new exported module named `PrivateInterface`. On iOS, no methods are exported. On Android, `onFSPressForward` is exported.

If this method is called, then we use reflection to find a new (in the upcoming `1.49.0` FS release) `FS.reactNative_exec_onFsPressForward_direct` method and invoke the press forwarding.

Note: This also changes our minimum supported RN version to `0.66.0`.