### PR TITLE
bugfix: fix inline require

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,14 +113,14 @@ const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
   supportedCommands: SUPPORTED_FS_ATTRIBUTES,
 });
 
+let getInternalInstanceHandleFromPublicInstance: Function | undefined;
+
+try {
+  getInternalInstanceHandleFromPublicInstance =
+    require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance').getInternalInstanceHandleFromPublicInstance;
+} catch (e) {}
+
 export function applyFSPropertiesWithRef(existingRef?: ForwardedRef<unknown>) {
-  let getInternalInstanceHandleFromPublicInstance: Function | undefined;
-
-  try {
-    getInternalInstanceHandleFromPublicInstance =
-      require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance').getInternalInstanceHandleFromPublicInstance;
-  } catch (e) {}
-
   return function (element: React.ElementRef<FSComponentType>) {
     if (isTurboModuleEnabled && Platform.OS === 'ios') {
       let currentProps: Record<keyof NativeCommands, string | object>;


### PR DESCRIPTION
Moving `require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance').getInternalInstanceHandleFromPublicInstance;` to outside the function body, so that it only needs to be imported once.

When the import was inside the function body, metro could not resolve this inline require (not sure why).

The current version works with RN 74, Old and New architecture, and RN versions <= 73 with Old architecture. 

This fixes RN versions <= 73 with New architecture.

RN 66 [session](https://app.staging.fullstory.com/ui/3RWN/session/5920355914809344:684040693366613108) (old)
RN 72 [session](https://app.staging.fullstory.com/ui/KWH/session/5896947218972672:3533583341178842338) (new)
RN 72 [[session](https://app.staging.fullstory.com/ui/KWH/session/5896947218972672:6353321689001844509)] (old)
RN 74 [session](https://app.staging.fullstory.com/ui/KWH/session/5023681300332544:432797448906230850 ) (new)