### PR TITLE
fix: add missing plist configs for ios

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -21,7 +21,9 @@ export type FullStoryAndroidProps = {
 } & FullStoryCrossPlatformProps;
 
 export type FullStoryIosProps = {
-  // placeholder
+  includeAssets: string[];
+  workaroundRNSVGCapture: boolean;
+  workaroundWKUserContentControllerRemoveAllUserScripts: boolean
 } & FullStoryCrossPlatformProps;
 
 type FullStoryPluginProps = FullStoryAndroidProps & FullStoryIosProps;

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -21,9 +21,9 @@ export type FullStoryAndroidProps = {
 } & FullStoryCrossPlatformProps;
 
 export type FullStoryIosProps = {
-  includeAssets: string[];
-  workaroundRNSVGCapture: boolean;
-  workaroundWKUserContentControllerRemoveAllUserScripts: boolean
+  [directory: string]: string[],
+  workaroundRNSVGCapture?: boolean;
+  workaroundWKUserContentControllerRemoveAllUserScripts?: boolean
 } & FullStoryCrossPlatformProps;
 
 type FullStoryPluginProps = FullStoryAndroidProps & FullStoryIosProps;

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -21,7 +21,7 @@ export type FullStoryAndroidProps = {
 } & FullStoryCrossPlatformProps;
 
 export type FullStoryIosProps = {
-  [directory: string]: string[],
+  includeAssets?: {[directory: string]: string[]};
   workaroundRNSVGCapture?: boolean;
   workaroundWKUserContentControllerRemoveAllUserScripts?: boolean
 } & FullStoryCrossPlatformProps;

--- a/plugin/src/withFullStoryIos.ts
+++ b/plugin/src/withFullStoryIos.ts
@@ -22,13 +22,18 @@ async function saveFileAsync(filePath: string, content: string) {
 
 const withInfoPlistDelegate: ConfigPlugin<FullStoryIosProps> = (
   expoConfig,
-  { org, host, recordOnStart },
+  { org, host, recordOnStart, includeAssets, workaroundRNSVGCapture, workaroundWKUserContentControllerRemoveAllUserScripts },
 ) =>
   withInfoPlist(expoConfig, config => {
     config.modResults.FullStory = {
       OrgId: org,
       Host: host,
       RecordOnStart: recordOnStart,
+      IncludeAssets: {
+        assets: includeAssets
+      },
+      NeedsWorkaroundRNSVGCapture: workaroundRNSVGCapture,
+      NeedsWorkaroundWKUserContentControllerRemoveAllUserScripts: workaroundWKUserContentControllerRemoveAllUserScripts
     };
     return config;
   });

--- a/plugin/src/withFullStoryIos.ts
+++ b/plugin/src/withFullStoryIos.ts
@@ -29,9 +29,7 @@ const withInfoPlistDelegate: ConfigPlugin<FullStoryIosProps> = (
       OrgId: org,
       Host: host,
       RecordOnStart: recordOnStart,
-      IncludeAssets: {
-        assets: includeAssets
-      },
+      IncludeAssets: includeAssets,
       NeedsWorkaroundRNSVGCapture: workaroundRNSVGCapture,
       NeedsWorkaroundWKUserContentControllerRemoveAllUserScripts: workaroundWKUserContentControllerRemoveAllUserScripts
     };


### PR DESCRIPTION
This PR adds in some missing plist options that we required in our product, the config fields are:

- includeAssets
- workaroundRNSVGCapture
- workaroundWKUserContentControllerRemoveAllUserScripts
