### PR TITLE
separate custom configs by platform

### DIFF
--- a/plugin/build/index.d.ts
+++ b/plugin/build/index.d.ts
@@ -6,7 +6,12 @@ type FullStoryCrossPlatformProps = {
     host?: string;
     recordOnStart?: boolean;
     additionalConfigs?: {
-        [configuration: string]: any;
+        ios?: {
+            [configuration: string]: any;
+        };
+        android?: {
+            [configuration: string]: any;
+        };
     };
 };
 export type FullStoryAndroidProps = {

--- a/plugin/build/withFullStoryAndroid.js
+++ b/plugin/build/withFullStoryAndroid.js
@@ -45,11 +45,12 @@ const withProjectGradleDelegate = (expoConfig, { version }) => {
 };
 function getCustomConfigs(additionalConfigs) {
     let customConfigs = '';
-    if (additionalConfigs) {
-        for (const key in additionalConfigs) {
-            customConfigs += `${key} ${typeof additionalConfigs[key] === 'string'
-                ? `'${additionalConfigs[key]}'`
-                : `${additionalConfigs[key]}`}\n`;
+    const androidConfigs = additionalConfigs === null || additionalConfigs === void 0 ? void 0 : additionalConfigs.android;
+    if (androidConfigs) {
+        for (const key in androidConfigs) {
+            customConfigs += `${key} ${typeof androidConfigs[key] === 'string'
+                ? `'${androidConfigs[key]}'`
+                : `${androidConfigs[key]}`}\n`;
         }
     }
     return customConfigs;

--- a/plugin/build/withFullStoryIos.js
+++ b/plugin/build/withFullStoryIos.js
@@ -19,7 +19,7 @@ const withInfoPlistDelegate = (expoConfig, { org, host, recordOnStart, includeAs
         IncludeAssets: includeAssets,
         NeedsWorkaroundRNSVGCapture: workaroundRNSVGCapture,
         NeedsWorkaroundWKUserContentControllerRemoveAllUserScripts: workaroundWKUserContentControllerRemoveAllUserScripts,
-        ...additionalConfigs,
+        ...additionalConfigs === null || additionalConfigs === void 0 ? void 0 : additionalConfigs.ios,
     };
     return config;
 });

--- a/plugin/src/__tests__/fixtures/fullstoryConfig.json
+++ b/plugin/src/__tests__/fixtures/fullstoryConfig.json
@@ -7,6 +7,8 @@
   "logcatLevel": "error",
   "recordOnStart": true,
   "additionalConfigs": {
-    "addDependencies": false
+    "android": {
+      "addDependencies": false
+    }
   }
 }

--- a/plugin/src/__tests__/withFullStoryAndroid.test.ts
+++ b/plugin/src/__tests__/withFullStoryAndroid.test.ts
@@ -62,9 +62,11 @@ describe('Config Plugin Android Tests', function () {
     result = addFullStoryGradlePlugin(result, {
       ...pluginConfigs,
       additionalConfigs: {
-        customBool: true,
-        anotherCustomConfig: '1.5.0',
-        anotherCustomNumberConfig: 3,
+        android: {
+          customBool: true,
+          anotherCustomConfig: '1.5.0',
+          anotherCustomNumberConfig: 3,
+        },
       },
     } as FullStoryAndroidProps);
     expect(result).toContain('customBool true');

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -12,7 +12,10 @@ type FullStoryCrossPlatformProps = {
   version: string;
   host?: string;
   recordOnStart?: boolean;
-  additionalConfigs?: { [configuration: string]: any };
+  additionalConfigs?: {
+    ios?: { [configuration: string]: any };
+    android?: { [configuration: string]: any };
+  };
 };
 
 export type FullStoryAndroidProps = {

--- a/plugin/src/withFullStoryAndroid.ts
+++ b/plugin/src/withFullStoryAndroid.ts
@@ -60,13 +60,14 @@ const withProjectGradleDelegate: ConfigPlugin<FullStoryAndroidProps> = (
 
 function getCustomConfigs(additionalConfigs: FullStoryAndroidProps['additionalConfigs']) {
   let customConfigs = '';
+  const androidConfigs = additionalConfigs?.android;
 
-  if (additionalConfigs) {
-    for (const key in additionalConfigs) {
+  if (androidConfigs) {
+    for (const key in androidConfigs) {
       customConfigs += `${key} ${
-        typeof additionalConfigs[key] === 'string'
-          ? `'${additionalConfigs[key]}'`
-          : `${additionalConfigs[key]}`
+        typeof androidConfigs[key] === 'string'
+          ? `'${androidConfigs[key]}'`
+          : `${androidConfigs[key]}`
       }\n`;
     }
   }

--- a/plugin/src/withFullStoryIos.ts
+++ b/plugin/src/withFullStoryIos.ts
@@ -41,7 +41,7 @@ const withInfoPlistDelegate: ConfigPlugin<FullStoryIosProps> = (
       NeedsWorkaroundRNSVGCapture: workaroundRNSVGCapture,
       NeedsWorkaroundWKUserContentControllerRemoveAllUserScripts:
         workaroundWKUserContentControllerRemoveAllUserScripts,
-      ...additionalConfigs,
+      ...additionalConfigs?.ios,
     };
     return config;
   });


### PR DESCRIPTION
It makes sense to separate custom configs by platform, so that they're not being applied to both platforms at once.