### PR TITLE
run click handler on UI thread

### DIFF
--- a/android/src/main/java/com/fullstory/reactnative/FullStoryPrivateModuleImpl.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryPrivateModuleImpl.java
@@ -45,7 +45,16 @@ public class FullStoryPrivateModuleImpl {
         if (reactTag == -1) {
             return;
         }
-        UIManager uiManager = UIManagerHelper.getUIManager(context, ViewUtil.getUIManagerType(reactTag));
+
+        UIManager uiManager;
+
+        try {
+            uiManager = UIManagerHelper.getUIManager(context, ViewUtil.getUIManagerType(reactTag));
+        } catch (Throwable t) {
+            // Silently ignore.
+            return;
+        }
+
         if (uiManager == null) {
             return;
         }


### PR DESCRIPTION
Currently, calling `uiManager.resolveView(reactTag);` causes React Native to throw a `SoftException`, because it [expects](https://github.com/facebook/react-native/blob/0fd4a9447e432b8c537825f571409f56ae63dc90/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java#L927) `FabricUIManager.resolveView` to be run on the UI thread. 

To avoid this error, we run our click handler on the UI thread.

Still needs to be tested on all the RN versions, but looking for early feedback on this.

[RN 74 Fabric Session](https://app.staging.fullstory.com/ui/KWH/session/3280449202851595977:4543370893277384711)

### Edit 7/12
[RN 66 Session ](https://app.staging.fullstory.com/ui/KWH/session/3378027069031434083:8327334863529245776)