### PR TITLE
MOCA-8077: capture uncaught exceptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "^2.2.0",
-        "@fullstory/babel-plugin-react-native": "^1.2.0"
+        "@fullstory/babel-plugin-react-native": "^1.3.0",
+        "@fullstory/safe-stringify": "^1.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.22.15",
@@ -36,7 +37,7 @@
       "peerDependencies": {
         "expo": ">=47.0.0",
         "react": "*",
-        "react-native": ">=0.61.0"
+        "react-native": ">=0.66.0"
       },
       "peerDependenciesMeta": {
         "expo": {
@@ -3176,13 +3177,18 @@
       "integrity": "sha512-JoRqy8KjPBWgYqOT+Uwnom76Ga43vjVh/pikE8OZKd5Magxp3j6VmmUCeWws/Ky2hiCWc2jc5kR6KjbapDDkLw=="
     },
     "node_modules/@fullstory/babel-plugin-react-native": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.2.0.tgz",
-      "integrity": "sha512-SN9sq0RUb6hV17ELdyQMBrAr9bwSLhj4tHHRWj3Fa+EDezzkq9sj0T5tampvrqmOs87OEnFsewx+ZF/ziuf2Rg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.3.0.tgz",
+      "integrity": "sha512-JSWV/fn5sEAUHhXD8CvyVTHAtttNjokLHguZ7pxh2EbG1TOg5yBCvXnF+yQ6heS5PKJen7TMS2mdBaXtnYEPIQ==",
       "dependencies": {
         "@babel/parser": "^7.0.0",
         "@babel/types": "^7.0.0"
       }
+    },
+    "node_modules/@fullstory/safe-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@fullstory/safe-stringify/-/safe-stringify-1.0.0.tgz",
+      "integrity": "sha512-KJEnmyxHc4T+E7Qe+eaCt+vl6zOxlcsfJ2cIzP1iYrg0B+HgbnTfcI4SRm1FNuOplYVUWwAcArIGpD2jMVVDOw=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -7246,9 +7252,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "@fullstory/babel-plugin-annotate-react": "^2.2.0",
-    "@fullstory/babel-plugin-react-native": "^1.3.0"
+    "@fullstory/babel-plugin-react-native": "^1.3.0",
+    "@fullstory/safe-stringify": "^1.0.0"
   },
   "peerDependencies": {
     "expo": ">=47.0.0",

--- a/setupTests.js
+++ b/setupTests.js
@@ -2,3 +2,4 @@ import { NativeModules } from 'react-native';
 import { jest } from '@jest/globals';
 
 NativeModules.FullStory = { startPage: jest.fn(), endPage: jest.fn(), updatePage: jest.fn() };
+global.__turboModuleProxy = null;

--- a/src/FSPage.ts
+++ b/src/FSPage.ts
@@ -1,8 +1,7 @@
 import { NativeModules } from 'react-native';
 import { generateUUID } from './utils';
 
-// @ts-expect-error
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+const isTurboModuleEnabled = __turboModuleProxy != null;
 
 type PropertiesWithoutPageName = {
   [key: string]: unknown;

--- a/src/FSPage.ts
+++ b/src/FSPage.ts
@@ -1,15 +1,9 @@
-import { NativeModules } from 'react-native';
 import { generateUUID } from './utils';
-
-const isTurboModuleEnabled = __turboModuleProxy != null;
+import { FullStory } from './core';
 
 type PropertiesWithoutPageName = {
   [key: string]: unknown;
 } & { pageName?: never };
-
-const FullStory = isTurboModuleEnabled
-  ? require('./NativeFullStory').default
-  : NativeModules.FullStory;
 
 const { startPage, endPage, updatePage } = FullStory;
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,119 @@
+import { NativeModules } from 'react-native';
+import { HostComponent, Platform } from 'react-native';
+import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
+import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
+import { ForwardedRef } from 'react';
+import setupReactNativeErrorHandler from './errorHandler';
+
+const isTurboModuleEnabled = __turboModuleProxy != null;
+
+export const FullStory = isTurboModuleEnabled
+  ? require('./NativeFullStory').default
+  : NativeModules.FullStory;
+
+export const FullStoryPrivate = isTurboModuleEnabled
+  ? require('./NativeFullStoryPrivate').default
+  : NativeModules.FullStoryPrivate;
+
+interface NativeProps extends ViewProps {
+  fsClass?: string;
+  fsAttribute?: object;
+  fsTagName?: string;
+  dataElement?: string;
+  dataSourceFile?: string;
+  dataComponent?: string;
+}
+
+type FSComponentType = HostComponent<NativeProps>;
+
+interface NativeCommands {
+  fsClass: (viewRef: React.ElementRef<FSComponentType>, fsClass: string) => void;
+  fsAttribute: (viewRef: React.ElementRef<FSComponentType>, fsAttribute: object) => void;
+  fsTagName: (viewRef: React.ElementRef<FSComponentType>, fsTagName: string) => void;
+  dataElement: (viewRef: React.ElementRef<FSComponentType>, dataElement: string) => void;
+  dataSourceFile: (viewRef: React.ElementRef<FSComponentType>, dataElement: string) => void;
+  dataComponent: (viewRef: React.ElementRef<FSComponentType>, dataElement: string) => void;
+}
+
+/* 
+    Calling these commands sequentially will *not* lead to an intermediate state where views
+    have incomplete attribute values. React's rendering phases protects against this race condition.
+    See DOC-1863 for more information.
+  */
+const SUPPORTED_FS_ATTRIBUTES = [
+  'fsClass',
+  'fsAttribute',
+  'fsTagName',
+  'dataElement',
+  'dataComponent',
+  'dataSourceFile',
+] as (keyof NativeCommands)[];
+
+const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: SUPPORTED_FS_ATTRIBUTES,
+});
+
+let getInternalInstanceHandleFromPublicInstance: Function | undefined;
+
+try {
+  getInternalInstanceHandleFromPublicInstance =
+    require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance').getInternalInstanceHandleFromPublicInstance;
+} catch (e) {}
+
+export function applyFSPropertiesWithRef(existingRef?: ForwardedRef<unknown>) {
+  return function (element: React.ElementRef<FSComponentType>) {
+    if (isTurboModuleEnabled && Platform.OS === 'ios') {
+      let currentProps: Record<keyof NativeCommands, string | object>;
+
+      if (getInternalInstanceHandleFromPublicInstance && element) {
+        currentProps =
+          getInternalInstanceHandleFromPublicInstance(element)?.stateNode?.canonical.currentProps;
+      } else {
+        // https://github.com/facebook/react-native/blob/87d2ea9c364c7ea393d11718c195dfe580c916ef/packages/react-native/Libraries/Components/TextInput/TextInputState.js#L109C23-L109C67
+        // @ts-expect-error `currentProps` is missing in `NativeMethods`
+        currentProps = element?.currentProps;
+      }
+      if (currentProps) {
+        const fsClass = currentProps.fsClass as string;
+        if (fsClass) {
+          Commands.fsClass(element, fsClass);
+        }
+
+        const fsAttribute = currentProps.fsAttribute as object;
+        if (fsAttribute) {
+          Commands.fsAttribute(element, fsAttribute);
+        }
+
+        const fsTagName = currentProps.fsTagName as string;
+        if (fsTagName) {
+          Commands.fsTagName(element, fsTagName);
+        }
+
+        const dataElement = currentProps.dataElement as string;
+        if (dataElement) {
+          Commands.dataElement(element, dataElement);
+        }
+
+        const dataComponent = currentProps.dataComponent as string;
+        if (dataComponent) {
+          Commands.dataComponent(element, dataComponent);
+        }
+
+        const dataSourceFile = currentProps.dataSourceFile as string;
+        if (dataSourceFile) {
+          Commands.dataSourceFile(element, dataSourceFile);
+        }
+      }
+    }
+
+    if (existingRef) {
+      if (existingRef instanceof Function) {
+        existingRef(element);
+      } else {
+        existingRef.current = element;
+      }
+    }
+  };
+}
+
+setupReactNativeErrorHandler();

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -1,0 +1,34 @@
+import { NativeModules } from 'react-native';
+import { safeStringify } from '@fullstory/safe-stringify';
+import { LogLevel } from './logging';
+
+const isTurboModuleEnabled = __turboModuleProxy != null;
+
+const FullStory = isTurboModuleEnabled
+  ? require('./NativeFullStory').default
+  : NativeModules.FullStory;
+
+const parseJSStackTrace = (error: Error) => {
+  if (!error || !error.stack) {
+    return [];
+  }
+  const parseErrorStack = require('react-native/Libraries/Core/Devtools/parseErrorStack');
+  return parseErrorStack(error.stack);
+};
+
+function setupReactNativeErrorHandler() {
+  const defaultHandler = ErrorUtils.getGlobalHandler();
+
+  ErrorUtils.setGlobalHandler((error, isFatal) => {
+    const stack = parseJSStackTrace(error);
+    const errorMessage = `${error.name}: ${error.message} ${safeStringify(stack)}`;
+
+    FullStory.log(LogLevel.Error, errorMessage);
+
+    if (defaultHandler) {
+      defaultHandler(error, isFatal);
+    }
+  });
+}
+
+export default setupReactNativeErrorHandler;

--- a/src/errorHandler.ts
+++ b/src/errorHandler.ts
@@ -1,12 +1,6 @@
-import { NativeModules } from 'react-native';
 import { safeStringify } from '@fullstory/safe-stringify';
 import { LogLevel } from './logging';
-
-const isTurboModuleEnabled = __turboModuleProxy != null;
-
-const FullStory = isTurboModuleEnabled
-  ? require('./NativeFullStory').default
-  : NativeModules.FullStory;
+import { FullStory } from './core';
 
 const parseJSStackTrace = (error: Error) => {
   if (!error || !error.stack) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,10 @@ import { HostComponent, NativeModules, Platform } from 'react-native';
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import { ForwardedRef } from 'react';
+import setupReactNativeErrorHandler from './errorHandler';
+import { LogLevel } from './logging';
 
-// @ts-expect-error
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+const isTurboModuleEnabled = __turboModuleProxy != null;
 
 interface NativeProps extends ViewProps {
   fsClass?: string;
@@ -37,15 +38,6 @@ const {
 const FullStoryPrivate = isTurboModuleEnabled
   ? require('./NativeFullStoryPrivate').default
   : NativeModules.FullStoryPrivate;
-
-export enum LogLevel {
-  Log = 0, // Clamps to Debug on iOS
-  Debug = 1,
-  Info = 2, // Default
-  Warn = 3,
-  Error = 4,
-  Assert = 5, // Clamps to Error on Android
-}
 
 interface UserVars {
   displayName?: string;
@@ -92,6 +84,7 @@ declare global {
       fsTagName?: string;
     }
   }
+  let __turboModuleProxy: boolean;
 }
 
 const identifyWithProperties = (uid: string, userVars = {}) => identify(uid, userVars);
@@ -189,6 +182,8 @@ export function applyFSPropertiesWithRef(existingRef?: ForwardedRef<unknown>) {
   };
 }
 
+setupReactNativeErrorHandler();
+
 const FullStoryAPI: FullStoryStatic = {
   anonymize,
   identify: identifyWithProperties,
@@ -208,4 +203,5 @@ const FullStoryAPI: FullStoryStatic = {
 export const PrivateInterface: FullStoryPrivateStatic =
   Platform.OS === 'android' ? { onFSPressForward: FullStoryPrivate.onFSPressForward } : {};
 
+export { LogLevel } from './logging';
 export default FullStoryAPI;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,6 @@
-import { HostComponent, NativeModules, Platform } from 'react-native';
-import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
-import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
-import { ForwardedRef } from 'react';
-import setupReactNativeErrorHandler from './errorHandler';
+import { Platform } from 'react-native';
 import { LogLevel } from './logging';
-
-const isTurboModuleEnabled = __turboModuleProxy != null;
-
-interface NativeProps extends ViewProps {
-  fsClass?: string;
-  fsAttribute?: object;
-  fsTagName?: string;
-  dataElement?: string;
-  dataSourceFile?: string;
-  dataComponent?: string;
-}
-
-const FullStory = isTurboModuleEnabled
-  ? require('./NativeFullStory').default
-  : NativeModules.FullStory;
+import { FullStory, FullStoryPrivate } from './core';
 
 const {
   anonymize,
@@ -34,10 +16,6 @@ const {
   log,
   resetIdleTimer,
 } = FullStory;
-
-const FullStoryPrivate = isTurboModuleEnabled
-  ? require('./NativeFullStoryPrivate').default
-  : NativeModules.FullStoryPrivate;
 
 interface UserVars {
   displayName?: string;
@@ -87,106 +65,11 @@ declare global {
   let __turboModuleProxy: boolean;
 }
 
-const identifyWithProperties = (uid: string, userVars = {}) => identify(uid, userVars);
-
 export { FSPage } from './FSPage';
-type FSComponentType = HostComponent<NativeProps>;
-
-interface NativeCommands {
-  fsClass: (viewRef: React.ElementRef<FSComponentType>, fsClass: string) => void;
-  fsAttribute: (viewRef: React.ElementRef<FSComponentType>, fsAttribute: object) => void;
-  fsTagName: (viewRef: React.ElementRef<FSComponentType>, fsTagName: string) => void;
-  dataElement: (viewRef: React.ElementRef<FSComponentType>, dataElement: string) => void;
-  dataSourceFile: (viewRef: React.ElementRef<FSComponentType>, dataElement: string) => void;
-  dataComponent: (viewRef: React.ElementRef<FSComponentType>, dataElement: string) => void;
-}
-
-/* 
-  Calling these commands sequentially will *not* lead to an intermediate state where views
-  have incomplete attribute values. React's rendering phases protects against this race condition.
-  See DOC-1863 for more information.
-*/
-const SUPPORTED_FS_ATTRIBUTES = [
-  'fsClass',
-  'fsAttribute',
-  'fsTagName',
-  'dataElement',
-  'dataComponent',
-  'dataSourceFile',
-] as (keyof NativeCommands)[];
-
-const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: SUPPORTED_FS_ATTRIBUTES,
-});
-
-let getInternalInstanceHandleFromPublicInstance: Function | undefined;
-
-try {
-  getInternalInstanceHandleFromPublicInstance =
-    require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance').getInternalInstanceHandleFromPublicInstance;
-} catch (e) {}
-
-export function applyFSPropertiesWithRef(existingRef?: ForwardedRef<unknown>) {
-  return function (element: React.ElementRef<FSComponentType>) {
-    if (isTurboModuleEnabled && Platform.OS === 'ios') {
-      let currentProps: Record<keyof NativeCommands, string | object>;
-
-      if (getInternalInstanceHandleFromPublicInstance && element) {
-        currentProps =
-          getInternalInstanceHandleFromPublicInstance(element)?.stateNode?.canonical.currentProps;
-      } else {
-        // https://github.com/facebook/react-native/blob/87d2ea9c364c7ea393d11718c195dfe580c916ef/packages/react-native/Libraries/Components/TextInput/TextInputState.js#L109C23-L109C67
-        // @ts-expect-error `currentProps` is missing in `NativeMethods`
-        currentProps = element?.currentProps;
-      }
-      if (currentProps) {
-        const fsClass = currentProps.fsClass as string;
-        if (fsClass) {
-          Commands.fsClass(element, fsClass);
-        }
-
-        const fsAttribute = currentProps.fsAttribute as object;
-        if (fsAttribute) {
-          Commands.fsAttribute(element, fsAttribute);
-        }
-
-        const fsTagName = currentProps.fsTagName as string;
-        if (fsTagName) {
-          Commands.fsTagName(element, fsTagName);
-        }
-
-        const dataElement = currentProps.dataElement as string;
-        if (dataElement) {
-          Commands.dataElement(element, dataElement);
-        }
-
-        const dataComponent = currentProps.dataComponent as string;
-        if (dataComponent) {
-          Commands.dataComponent(element, dataComponent);
-        }
-
-        const dataSourceFile = currentProps.dataSourceFile as string;
-        if (dataSourceFile) {
-          Commands.dataSourceFile(element, dataSourceFile);
-        }
-      }
-    }
-
-    if (existingRef) {
-      if (existingRef instanceof Function) {
-        existingRef(element);
-      } else {
-        existingRef.current = element;
-      }
-    }
-  };
-}
-
-setupReactNativeErrorHandler();
 
 const FullStoryAPI: FullStoryStatic = {
   anonymize,
-  identify: identifyWithProperties,
+  identify: (uid: string, userVars = {}) => identify(uid, userVars),
   setUserVars,
   onReady,
   getCurrentSession,
@@ -204,4 +87,5 @@ export const PrivateInterface: FullStoryPrivateStatic =
   Platform.OS === 'android' ? { onFSPressForward: FullStoryPrivate.onFSPressForward } : {};
 
 export { LogLevel } from './logging';
+export { applyFSPropertiesWithRef } from './core';
 export default FullStoryAPI;

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,8 @@
+export enum LogLevel {
+  Log = 0, // Clamps to Debug on iOS
+  Debug = 1,
+  Info = 2, // Default
+  Warn = 3,
+  Error = 4,
+  Assert = 5, // Clamps to Error on Android
+}


### PR DESCRIPTION
[MOCA-8077](https://fullstory.atlassian.net/browse/MOCA-8077)
Implement React Native unhandled exception logger in `eventHandler.ts`, sending stack trace information to `FS.log`. Defaulting this on `ON` to avoid manual user implementation.

[Sample session](https://app.staging.fullstory.com/ui/KWH/session/5023681300332544:1216163673456140521/devtools/console).

Open questions:
We don't have `FS.log` scrubbing in mobile. I know we scrub logs in [web](https://github.com/cowpaths/mn/blob/c511a64aa481652362bf6fae80fccf78bfe8d02b/projects/fullstory/packages/recording/src/consolewatcher.ts#L57). Is this a concern? @jurassix 