### PR TITLE
Avoid a potential initialization loop

### DIFF
--- a/ios/FullStory.mm
+++ b/ios/FullStory.mm
@@ -393,11 +393,12 @@ static bool array_contains_string(const char **array, const char *string) {
         SWIZZLED_METHOD();
         
         UIViewController *viewController = self;
-        
+        RCTView *view = (RCTView *)[viewController viewIfLoaded];
+
         if ([self respondsToSelector:@selector(layoutInfo)]) {
             id layoutInfo = [self performSelector:@selector(layoutInfo)];
-            if ([layoutInfo respondsToSelector:@selector(name)]) {
-                set_fsAttribute(@{@"screen-name": [layoutInfo name]}, (RCTView *)viewController.view);
+            if (view && [layoutInfo respondsToSelector:@selector(name)]) {
+                set_fsAttribute(@{@"screen-name": [layoutInfo name]}, view);
             }
         } else {
             NSLog(@"RNNComponentViewController cannot communicate screen names to FullStory. Navigation events and screen selectors may not function correctly.");


### PR DESCRIPTION
VAL-8909

View controllers manage a `view`, including loading it if necessary via `loadView` when the `view` property is accessed. React Native Navigation's `RNNComponentViewController` calls `renderReactViewIfNeeded` to load the view, which typically loads both the view controller's `view` and a `reactView`.

However, it's possible for this RNN view controller to end up with a `reactView` but no `view` - my best guess is we're seeing it after UIKit has partially unloaded the view controller, but it of course doesn't know about the `reactView` field. Triggering `loadView` in such a state actually does nothing, because [there's an initial check for the presence of `reactView` ](https://github.com/wix/react-native-navigation/blob/efee2bdb8af6b0c3696c1c611f4b1492f60abbca/lib/ios/RNNComponentViewController.m#L85). Then our swizzle would end up accessing an unloaded `view`, causing an infinite loop.

We can access the view we want to give a screen name via `[UIViewController viewIfLoaded]`, avoiding possibly triggering any loader. This means we'll fail to tag the view, which isn't a problem in the situations I've been able to reproduce as the screen is about to go away, anyway, but in case there are other ways this can happen, we check `reactView`'s parent (which would normally be the `view`), too. 