### PR TITLE
Fix new architecture detection

### DIFF
--- a/src/FSPage.ts
+++ b/src/FSPage.ts
@@ -1,8 +1,5 @@
 import { NativeModules } from 'react-native';
-import { generateUUID } from './utils';
-
-// @ts-expect-error
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+import { generateUUID, isTurboModuleEnabled } from './utils';
 
 type PropertiesWithoutPageName = {
   [key: string]: unknown;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,7 @@ import { HostComponent, NativeModules, Platform } from 'react-native';
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import { ForwardedRef } from 'react';
-
-// @ts-expect-error
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+import { isTurboModuleEnabled } from './utils';
 
 interface NativeProps extends ViewProps {
   fsClass?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,12 @@
 /* eslint-disable no-bitwise */
 
+declare const global: {
+  RN$Bridgeless?: boolean;
+  __turboModuleProxy?: unknown;
+};
+
+export const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
+
 export const generateUUID = (function () {
   function hex8(n: number) {
     return ((n >>> 0) + 4294967296).toString(16).substring(1).toUpperCase();


### PR DESCRIPTION
RN versions >=0.77 will use global.RN$Bridgeless as an indicator of whether New Architecture is enabled.