### PR TITLE
VAL-9294: Provide noop API for web environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
       - run:
           name: Audit
-          command: npm audit --audit-level=low --production
+          command: npm audit --audit-level=low --omit=dev
       - run:
           name: Lint
           command: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -417,12 +417,12 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
-      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -506,11 +506,11 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.8.tgz",
-      "integrity": "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dependencies": {
-        "@babel/types": "^7.26.8"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2139,9 +2139,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2155,13 +2155,13 @@
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@babel/template": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.8.tgz",
-      "integrity": "sha512-iNKaX3ZebKIsCvJ+0jd6embf+Aulaa3vNBqZ41kM7iTWjx5qzWKXGHiJUW3+nTpQ18SG11hdF8OAzKrpXkb96Q==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.8",
-        "@babel/types": "^7.26.8"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2244,9 +2244,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.8.tgz",
-      "integrity": "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -10218,9 +10218,9 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.0.tgz",
-      "integrity": "sha512-4S8fwbO6w3GeCVN6OPtA9I5IGKkcDMPcKndtUlpJuCwu7JLjtj7JZpwqLuyY2nrmQT3AWsCJLSKPsc2mPBSl3w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
       "peer": true,
       "dependencies": {
         "queue": "6.0.2"

--- a/src/NativeFullStory.ts
+++ b/src/NativeFullStory.ts
@@ -1,6 +1,6 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
-import { OnReadyResponse } from '.';
+import { OnReadyResponse } from './fullstoryInterface';
 
 export interface Spec extends TurboModule {
   anonymize(): void;

--- a/src/fullstoryInterface.ts
+++ b/src/fullstoryInterface.ts
@@ -1,0 +1,45 @@
+interface UserVars {
+  displayName?: string;
+  email?: string;
+  [key: string]: any;
+}
+export type OnReadyResponse = {
+  replayStartUrl: string;
+  replayNowUrl: string;
+  sessionId: string;
+};
+
+export enum LogLevel {
+  Log = 0, // Clamps to Debug on iOS
+  Debug = 1,
+  Info = 2, // Default
+  Warn = 3,
+  Error = 4,
+  Assert = 5, // Clamps to Error on Android
+}
+
+export declare type FullstoryStatic = {
+  LogLevel: typeof LogLevel;
+  anonymize(): void;
+  identify(uid: string, userVars?: UserVars): void;
+  setUserVars(userVars: UserVars): void;
+  onReady(): Promise<OnReadyResponse>;
+  getCurrentSession(): Promise<string>;
+  getCurrentSessionURL(): Promise<string>;
+  consent(userConsents: boolean): void;
+  event(eventName: string, eventProperties: Object): void;
+  shutdown(): void;
+  restart(): void;
+  log(logLevel: LogLevel, message: string): void;
+  resetIdleTimer(): void;
+};
+
+declare global {
+  namespace JSX {
+    interface IntrinsicAttributes {
+      fsAttribute?: { [key: string]: string };
+      fsClass?: string;
+      fsTagName?: string;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativ
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import { ForwardedRef } from 'react';
 import { isTurboModuleEnabled } from './utils';
+import { FullstoryStatic, LogLevel } from './fullstoryInterface';
 
 interface NativeProps extends ViewProps {
   fsClass?: string;
@@ -36,43 +37,6 @@ const FullStoryPrivate = isTurboModuleEnabled
   ? require('./NativeFullStoryPrivate').default
   : NativeModules.FullStoryPrivate;
 
-export enum LogLevel {
-  Log = 0, // Clamps to Debug on iOS
-  Debug = 1,
-  Info = 2, // Default
-  Warn = 3,
-  Error = 4,
-  Assert = 5, // Clamps to Error on Android
-}
-
-interface UserVars {
-  displayName?: string;
-  email?: string;
-  [key: string]: any;
-}
-
-export type OnReadyResponse = {
-  replayStartUrl: string;
-  replayNowUrl: string;
-  sessionId: string;
-};
-
-declare type FullStoryStatic = {
-  LogLevel: typeof LogLevel;
-  anonymize(): void;
-  identify(uid: string, userVars?: UserVars): void;
-  setUserVars(userVars: UserVars): void;
-  onReady(): Promise<OnReadyResponse>;
-  getCurrentSession(): Promise<string>;
-  getCurrentSessionURL(): Promise<string>;
-  consent(userConsents: boolean): void;
-  event(eventName: string, eventProperties: Object): void;
-  shutdown(): void;
-  restart(): void;
-  log(logLevel: LogLevel, message: string): void;
-  resetIdleTimer(): void;
-};
-
 declare type FullStoryPrivateStatic = {
   onFSPressForward?(
     tag: number,
@@ -81,16 +45,6 @@ declare type FullStoryPrivateStatic = {
     hasLongPressHandler: boolean,
   ): void;
 };
-
-declare global {
-  namespace JSX {
-    interface IntrinsicAttributes {
-      fsAttribute?: { [key: string]: string };
-      fsClass?: string;
-      fsTagName?: string;
-    }
-  }
-}
 
 const identifyWithProperties = (uid: string, userVars = {}) => identify(uid, userVars);
 
@@ -187,7 +141,7 @@ export function applyFSPropertiesWithRef(existingRef?: ForwardedRef<unknown>) {
   };
 }
 
-const FullStoryAPI: FullStoryStatic = {
+const FullstoryAPI: FullstoryStatic = {
   anonymize,
   identify: identifyWithProperties,
   setUserVars,
@@ -206,4 +160,4 @@ const FullStoryAPI: FullStoryStatic = {
 export const PrivateInterface: FullStoryPrivateStatic =
   Platform.OS === 'android' ? { onFSPressForward: FullStoryPrivate.onFSPressForward } : {};
 
-export default FullStoryAPI;
+export default FullstoryAPI;

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -1,0 +1,29 @@
+import { FullstoryStatic, LogLevel } from './fullstoryInterface';
+
+const warningMessage = 'Fullstory React Native is not supported on web';
+
+const noop = () => {
+  console.warn(warningMessage);
+};
+
+const noopPromise = () => {
+  return Promise.reject(new Error(warningMessage));
+};
+
+const FullstoryAPI: FullstoryStatic = {
+  LogLevel,
+  anonymize: noop,
+  identify: noop,
+  setUserVars: noop,
+  onReady: noopPromise,
+  getCurrentSession: noopPromise,
+  getCurrentSessionURL: noopPromise,
+  consent: noop,
+  event: noop,
+  shutdown: noop,
+  restart: noop,
+  log: noop,
+  resetIdleTimer: noop,
+};
+
+export default FullstoryAPI;


### PR DESCRIPTION
[VAL-9294](https://fullstory.atlassian.net/browse/VAL-9294)

This work aims at avoiding module resolution errors when Expo's metro is bundling for a web environment. We create an `index.web.ts` and react native will automatically resolve to that file in a web environment, which will avoid importing native only modules.