### PR TITLE
Synchronize invoking the onReady callback

### DIFF
--- a/ios/FullStory.mm
+++ b/ios/FullStory.mm
@@ -188,7 +188,9 @@ RCT_EXPORT_METHOD(updatePage:(NSString *)nonce pageProperties:(NSDictionary *)pa
 }
 
 - (void) onReady:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
-  	onReadyPromise = resolve;
+    @synchronized (self) {
+        onReadyPromise = [resolve copy];
+    }
 	FS.delegate = self;
 
 	if (FS.currentSessionURL) {

--- a/ios/FullStory.mm
+++ b/ios/FullStory.mm
@@ -171,16 +171,20 @@ RCT_EXPORT_METHOD(updatePage:(NSString *)nonce pageProperties:(NSDictionary *)pa
 }
 
 - (void) fullstoryDidStartSession:(NSString *)sessionUrl {
-	if (!onReadyPromise)
-		return;
+    // this method can be executed both by onReady below and by the Fullstory SDK,
+    // because this object is a delegate, so avoid any possible race
+    @synchronized (self) {
+        if (!onReadyPromise)
+            return;
 
-	NSMutableDictionary *dict = [NSMutableDictionary new];
-	dict[@"replayStartUrl"] = sessionUrl;
-	dict[@"replayNowUrl"] = [FS currentSessionURL: true];
-	dict[@"sessionId"] = FS.currentSession;
-	onReadyPromise(dict);
+        NSMutableDictionary *dict = [NSMutableDictionary new];
+        dict[@"replayStartUrl"] = sessionUrl;
+        dict[@"replayNowUrl"] = [FS currentSessionURL: true];
+        dict[@"sessionId"] = FS.currentSession;
+        onReadyPromise(dict);
 
-	onReadyPromise = nil;
+        onReadyPromise = nil;
+    }
 }
 
 - (void) onReady:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {


### PR DESCRIPTION
A customer experienced a rare crash that seems consistent with a race in accessing the resolve callback passed in from the javascript onReady API. If called at just the right time, the delegate could try to invoke the callback at the same time as the code setting the callback, leading to it being nulled out just before one of them calls it.