### PR TITLE
update types for React 19

### DIFF
--- a/src/fullstoryInterface.ts
+++ b/src/fullstoryInterface.ts
@@ -43,3 +43,15 @@ declare global {
     }
   }
 }
+
+// React 19+
+// https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicAttributes {
+      fsAttribute?: { [key: string]: string };
+      fsClass?: string;
+      fsTagName?: string;
+    }
+  }
+}

--- a/src/fullstoryInterface.ts
+++ b/src/fullstoryInterface.ts
@@ -34,18 +34,6 @@ export declare type FullstoryStatic = {
   resetIdleTimer(): void;
 };
 
-declare global {
-  namespace JSX {
-    interface IntrinsicAttributes {
-      fsAttribute?: { [key: string]: string };
-      fsClass?: string;
-      fsTagName?: string;
-    }
-  }
-}
-
-// React 19+
-// https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript
 declare module 'react' {
   namespace JSX {
     interface IntrinsicAttributes {


### PR DESCRIPTION
React 19 has removed `JSX` from the global namespace. 
https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript

Thanks @bhandanyan-nomad for raising this issue.