### PR TITLE
WECA-1403: fix metro import error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2645,9 +2645,9 @@
       }
     },
     "node_modules/@expo/devcert/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6393,9 +6393,9 @@
       }
     },
     "node_modules/babel-plugin-module-resolver/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6702,9 +6702,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -15873,9 +15873,9 @@
       }
     },
     "node_modules/react-native-builder-bob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/src/FSPage.ts
+++ b/src/FSPage.ts
@@ -1,5 +1,6 @@
 import { NativeModules } from 'react-native';
-import { generateUUID, isTurboModuleEnabled } from './utils';
+import { isTurboModuleEnabled } from './fullstoryInterface';
+import { generateUUID } from './utils';
 
 type PropertiesWithoutPageName = {
   [key: string]: unknown;

--- a/src/fullstoryInterface.ts
+++ b/src/fullstoryInterface.ts
@@ -1,3 +1,10 @@
+declare const global: {
+  RN$Bridgeless?: boolean;
+  __turboModuleProxy?: unknown;
+};
+
+export const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
+
 interface UserVars {
   displayName?: string;
   email?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+// When adding new imports, please verify that they are not causing the metro resolver to fail in earlier versions of react-native.
 import { HostComponent, NativeModules, Platform } from 'react-native';
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
@@ -80,6 +81,7 @@ const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
 let getInternalInstanceHandleFromPublicInstance: Function | undefined;
 
 try {
+  // This import confuses the metro resolver in earlier versions of react-native.
   getInternalInstanceHandleFromPublicInstance =
     require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance').getInternalInstanceHandleFromPublicInstance;
 } catch (e) {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,7 @@ import { HostComponent, NativeModules, Platform } from 'react-native';
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import { ForwardedRef } from 'react';
-import { isTurboModuleEnabled } from './utils';
-import { FullstoryStatic, LogLevel } from './fullstoryInterface';
+import { FullstoryStatic, isTurboModuleEnabled, LogLevel } from './fullstoryInterface';
 
 interface NativeProps extends ViewProps {
   fsClass?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,4 @@
 /* eslint-disable no-bitwise */
-
-declare const global: {
-  RN$Bridgeless?: boolean;
-  __turboModuleProxy?: unknown;
-};
-
-export const isTurboModuleEnabled = global.RN$Bridgeless || global.__turboModuleProxy != null;
-
 export const generateUUID = (function () {
   function hex8(n: number) {
     return ((n >>> 0) + 4294967296).toString(16).substring(1).toUpperCase();


### PR DESCRIPTION
https://fullstory.slack.com/archives/C1DAWDPM3/p1749760541114209

**Context**
Customer reported a metro import error for version RN 72. This doesn't error doesn't exist in newer versions of React Native (79, 80), so the issue should be resolved by metro. This refactor is for backwards compatibility.

**Issue**
In `index.ts`, the existence of this import: `getInternalInstanceHandleFromPublicInstance =
    require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance').getInternalInstanceHandleFromPublicInstance;` causes older metro to fail to resolve importing `LogLevel`. 
    
**Solution**
This issue seems to resolve itself if `LogLevel` is moved to a file that exports another value. This PR simply moves `global` and `isTurboModuleEnabled` to another file, so that the `LogLevel` doesn't break metro. 

Tested with React Native 66, 72, and 80.