### PR TITLE
chore: bump @fullstory/babel-plugin-react-native to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "^2.2.0",
-        "@fullstory/babel-plugin-react-native": "^1.3.1"
+        "@fullstory/babel-plugin-react-native": "^1.4.0"
       },
       "devDependencies": {
         "@babel/core": "^7.22.15",
@@ -3134,9 +3134,10 @@
       "integrity": "sha512-JoRqy8KjPBWgYqOT+Uwnom76Ga43vjVh/pikE8OZKd5Magxp3j6VmmUCeWws/Ky2hiCWc2jc5kR6KjbapDDkLw=="
     },
     "node_modules/@fullstory/babel-plugin-react-native": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.3.1.tgz",
-      "integrity": "sha512-SQupmuKVR1Hh1mzfjtNftd+9MGwkXLVaR2Vzcj+LOTLK/3Pkls9oTlUBvec7dQ4XjQhDUw+GXj1NRUPkjMen0g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.4.0.tgz",
+      "integrity": "sha512-sD9ykIeJp+NvHRiMJmI6GTR6cwE9y/0xwFBEDkAUFcy9XvV3uzF1sFwq/umLJLa7WZLKN/QprcDSYhdLXGyQfQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.0.0",
         "@babel/types": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fullstory/babel-plugin-annotate-react": "^2.2.0",
-    "@fullstory/babel-plugin-react-native": "^1.3.1"
+    "@fullstory/babel-plugin-react-native": "^1.4.0"
   },
   "peerDependencies": {
     "expo": ">=47.0.0",


### PR DESCRIPTION
Bumps @fullstory/babel-plugin-react-native to 1.4.0 which adds support for RN 0.78 and React 19 so that the dependency doesn't need to be pinned by the project using this dependency.