### PR TITLE
VAL-9669: add lottie and webview to swizzle

### DIFF
--- a/ios/FullStory.mm
+++ b/ios/FullStory.mm
@@ -445,6 +445,9 @@ static bool array_contains_string(const char **array, const char *string) {
         "RCTScrollViewComponentView",
         "RCTPullToRefreshViewComponentView",
         "RCTLegacyViewManagerInteropComponentView",
+        "RNCPagerViewComponentView",
+        "LottieAnimationViewComponentView",
+        "RNCWebView",
         0};
     // Grab the impl of RCTViewComponentView
     Class viewComponentView = NSClassFromString(@"RCTViewComponentView");

--- a/ios/FullStory.mm
+++ b/ios/FullStory.mm
@@ -395,6 +395,7 @@ static bool array_contains_string(const char **array, const char *string) {
     SWIZZLE_HANDLE_COMMAND(RCTLegacyViewManagerInteropComponentView);
     SWIZZLE_HANDLE_COMMAND(RNCPagerViewComponentView);
     SWIZZLE_HANDLE_COMMAND(LottieAnimationViewComponentView);
+    SWIZZLE_HANDLE_COMMAND(RNCWebView);
 #pragma clang pop
 
 #pragma clang diagnostic push

--- a/ios/FullStory.mm
+++ b/ios/FullStory.mm
@@ -394,6 +394,7 @@ static bool array_contains_string(const char **array, const char *string) {
     SWIZZLE_HANDLE_COMMAND(RCTPullToRefreshViewComponentView);
     SWIZZLE_HANDLE_COMMAND(RCTLegacyViewManagerInteropComponentView);
     SWIZZLE_HANDLE_COMMAND(RNCPagerViewComponentView);
+    SWIZZLE_HANDLE_COMMAND(LottieAnimationViewComponentView);
 #pragma clang pop
 
 #pragma clang diagnostic push

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ try {
     require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance').getInternalInstanceHandleFromPublicInstance;
 } catch (e) {}
 
-const FS_REF_SYMBOL = Symbol('fullstory.ref');
+export const FS_REF_SYMBOL = Symbol('fullstory.ref');
 
 type MaybeFSForwardedRef<T> = ForwardedRef<T> & {
   [FS_REF_SYMBOL]?: boolean;


### PR DESCRIPTION
In addition to the swizzle commands, we're exporting FS_REF_SYMBOL so that the babel plugin has access to it to fix another issue.