### PR TITLE
fix: update phantom ref test from failing to passing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "^2.3.2",
-        "@fullstory/babel-plugin-react-native": "^1.6.1"
+        "@fullstory/babel-plugin-react-native": "github:TaduJR/fullstory-babel-plugin-react-native#fix/react-19-non-enumerable-synthetic-refs"
       },
       "devDependencies": {
         "@babel/core": "^7.22.15",
@@ -2867,8 +2867,7 @@
     },
     "node_modules/@fullstory/babel-plugin-react-native": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.6.1.tgz",
-      "integrity": "sha512-bRKzMdYdZlG1RKVNJMv3UXmXvJ2OIdvpwsOxJzCnG0LTINv8bqJ2s/9pXIj1O73ppPDfWRESMChlPjEn5JcLuw==",
+      "resolved": "git+ssh://git@github.com/TaduJR/fullstory-babel-plugin-react-native.git#eb48ffaf44178707dea50b7bf97d8e285121de06",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "^2.3.2",
-        "@fullstory/babel-plugin-react-native": "^1.6.3"
+        "@fullstory/babel-plugin-react-native": "^1.6.4"
       },
       "devDependencies": {
         "@babel/core": "^7.22.15",
@@ -2866,9 +2866,9 @@
       }
     },
     "node_modules/@fullstory/babel-plugin-react-native": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.6.3.tgz",
-      "integrity": "sha512-ucjtEoMB+VihR0jQQRNjIUZsrTW6RZ+S3aJVPiMmTQFEQmYAvv1rDf29ctVyWKPf+7tdK6HA29d9khRYuWvvoA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.6.4.tgz",
+      "integrity": "sha512-eAtZAi9lrZIPnhT3sUUvbDBy8F6H1mjBI/cEtNa1tE3UlTltwqYI4q3KjHQn0gociJuFEdLtOEKPFpUsvP23/A==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "^2.3.2",
-        "@fullstory/babel-plugin-react-native": "github:TaduJR/fullstory-babel-plugin-react-native#fix/react-19-non-enumerable-synthetic-refs"
+        "@fullstory/babel-plugin-react-native": "^1.6.1"
       },
       "devDependencies": {
         "@babel/core": "^7.22.15",
@@ -2867,7 +2867,8 @@
     },
     "node_modules/@fullstory/babel-plugin-react-native": {
       "version": "1.6.1",
-      "resolved": "git+ssh://git@github.com/TaduJR/fullstory-babel-plugin-react-native.git#eb48ffaf44178707dea50b7bf97d8e285121de06",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.6.1.tgz",
+      "integrity": "sha512-bRKzMdYdZlG1RKVNJMv3UXmXvJ2OIdvpwsOxJzCnG0LTINv8bqJ2s/9pXIj1O73ppPDfWRESMChlPjEn5JcLuw==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "^2.3.2",
-        "@fullstory/babel-plugin-react-native": "^1.6.1"
+        "@fullstory/babel-plugin-react-native": "^1.6.3"
       },
       "devDependencies": {
         "@babel/core": "^7.22.15",
@@ -2866,9 +2866,9 @@
       }
     },
     "node_modules/@fullstory/babel-plugin-react-native": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.6.1.tgz",
-      "integrity": "sha512-bRKzMdYdZlG1RKVNJMv3UXmXvJ2OIdvpwsOxJzCnG0LTINv8bqJ2s/9pXIj1O73ppPDfWRESMChlPjEn5JcLuw==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@fullstory/babel-plugin-react-native/-/babel-plugin-react-native-1.6.3.tgz",
+      "integrity": "sha512-ucjtEoMB+VihR0jQQRNjIUZsrTW6RZ+S3aJVPiMmTQFEQmYAvv1rDf29ctVyWKPf+7tdK6HA29d9khRYuWvvoA==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@fullstory/babel-plugin-annotate-react": "^2.3.2",
-    "@fullstory/babel-plugin-react-native": "github:TaduJR/fullstory-babel-plugin-react-native#fix/react-19-non-enumerable-synthetic-refs"
+    "@fullstory/babel-plugin-react-native": "^1.6.1"
   },
   "peerDependencies": {
     "expo": ">=47.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@fullstory/babel-plugin-annotate-react": "^2.3.2",
-    "@fullstory/babel-plugin-react-native": "^1.6.1"
+    "@fullstory/babel-plugin-react-native": "^1.6.3"
   },
   "peerDependencies": {
     "expo": ">=47.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@fullstory/babel-plugin-annotate-react": "^2.3.2",
-    "@fullstory/babel-plugin-react-native": "^1.6.3"
+    "@fullstory/babel-plugin-react-native": "^1.6.4"
   },
   "peerDependencies": {
     "expo": ">=47.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@fullstory/babel-plugin-annotate-react": "^2.3.2",
-    "@fullstory/babel-plugin-react-native": "^1.6.1"
+    "@fullstory/babel-plugin-react-native": "github:TaduJR/fullstory-babel-plugin-react-native#fix/react-19-non-enumerable-synthetic-refs"
   },
   "peerDependencies": {
     "expo": ">=47.0.0",

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -151,7 +151,7 @@ describe('Reading FS properties on iOS', () => {
     expect(ref).toHaveBeenLastCalledWith(null);
   });
 
-  it.failing(
+  it(
     'custom component with FS attributes does not have phantom ref injected into its props',
     () => {
       const childRef = React.createRef<View>();

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -151,23 +151,20 @@ describe('Reading FS properties on iOS', () => {
     expect(ref).toHaveBeenLastCalledWith(null);
   });
 
-  it(
-    'custom component with FS attributes does not have phantom ref injected into its props',
-    () => {
-      const childRef = React.createRef<View>();
+  it('custom component with FS attributes does not have phantom ref injected into its props', () => {
+    const childRef = React.createRef<View>();
 
-      const CustomComponent = (props: { fsClass?: string; children?: React.ReactNode }) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { fsClass: _fsClass, ...rest } = props;
-        return <View ref={childRef} {...rest} />;
-      };
+    const CustomComponent = (props: { fsClass?: string; children?: React.ReactNode }) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { fsClass: _fsClass, ...rest } = props;
+      return <View ref={childRef} {...rest} />;
+    };
 
-      render(<CustomComponent fsClass={fsClassValue} />);
+    render(<CustomComponent fsClass={fsClassValue} />);
 
-      expect(childRef.current).not.toBeNull();
-      expect((childRef.current as any)?._reactInternals?.type).toBe(View);
-    },
-  );
+    expect(childRef.current).not.toBeNull();
+    expect((childRef.current as any)?._reactInternals?.type).toBe(View);
+  });
 
   it('component without FS attributes does not trigger setBatchProperties', () => {
     render(<View />);

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -151,21 +151,6 @@ describe('Reading FS properties on iOS', () => {
     expect(ref).toHaveBeenLastCalledWith(null);
   });
 
-  it('custom component with FS attributes does not have phantom ref injected into its props', () => {
-    const childRef = React.createRef<View>();
-
-    const CustomComponent = (props: { fsClass?: string; children?: React.ReactNode }) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { fsClass: _fsClass, ...rest } = props;
-      return <View ref={childRef} {...rest} />;
-    };
-
-    render(<CustomComponent fsClass={fsClassValue} />);
-
-    expect(childRef.current).not.toBeNull();
-    expect((childRef.current as any)?._reactInternals?.type).toBe(View);
-  });
-
   it('component without FS attributes does not trigger setBatchProperties', () => {
     render(<View />);
     expect(mockNativeCommands.setBatchProperties).not.toHaveBeenCalled();


### PR DESCRIPTION
### Summary

Updates the `it.failing` test added in #149 to `it`, since the phantom ref injection bug is now fixed by fullstorydev/fullstory-babel-plugin-react-native#64.

The non-enumerable synthetic ref fix in the babel plugin prevents `sharedRefWrapper` from leaking through `{...rest}` spreads in custom components, so the test now passes as expected.

### Dependency

This PR should land **after** fullstorydev/fullstory-babel-plugin-react-native#64 is merged and a new version of `@fullstory/babel-plugin-react-native` is published.