### PR TITLE
iOS new architecture: migrate away from ref rewriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,15 +85,15 @@ Place the `handleCommand` check under the `DEBUG_FS_RN_FABRIC_THIRD_PARTY` prepr
 
 ## 1.4.1
 
-Updated the minimum version for the FullStory `@fullstory/babel-plugin-react-native` babel plugin to `1.1.0` for New Architecture support.
+Updated the minimum version for the Fullstory `@fullstory/babel-plugin-react-native` babel plugin to `1.1.0` for New Architecture support.
 
 ## 1.4.0
 
-Added support for the [React Native New Architecture](https://reactnative.dev/docs/the-new-architecture/landing-page) (this includes support for Fabric and Turbo Native Modules). Refer to the [New Architecture](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-FullStory-React-Native-Capture#01HHCXMMZQ970DRWFA0XC03ER4) section of the FullStory React Native Getting Started guide for more information about minimum SDK and plugin versions.
+Added support for the [React Native New Architecture](https://reactnative.dev/docs/the-new-architecture/landing-page) (this includes support for Fabric and Turbo Native Modules). Refer to the [New Architecture](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-Fullstory-React-Native-Capture#01HHCXMMZQ970DRWFA0XC03ER4) section of the Fullstory React Native Getting Started guide for more information about minimum SDK and plugin versions.
 
 ## 1.3.0
 
-Add support for FullStory Pages API.
+Add support for Fullstory Pages API.
 Set up tsconfig and update TypeScript types.
 
 ## 1.2.1
@@ -108,7 +108,7 @@ Update gradle configs.
 
 ## 1.1.2
 
-Updated the minimum version for the FullStory `@fullstory/babel-plugin-react-native` babel plugin to `1.0.3` to fix attributes in RN 71.
+Updated the minimum version for the Fullstory `@fullstory/babel-plugin-react-native` babel plugin to `1.0.3` to fix attributes in RN 71.
 Add dependency overrides to fix `npm audit` warnings.
 
 ## 1.1.1
@@ -125,19 +125,19 @@ Added `FS.resetIdleTimer` to the TypeScript types.
 
 ## 1.0.6
 
-Added support for calling `FS.resetIdleTimer`. This release now requires a minimum FullStory plugin version of `1.14.0`.
+Added support for calling `FS.resetIdleTimer`. This release now requires a minimum Fullstory plugin version of `1.14.0`.
 
 ## 1.0.5
 
-Updated the minimum version for the FullStory `@fullstory/babel-plugin-react-native` babel plugin to 1.0.2, to better work around metro server issues.
+Updated the minimum version for the Fullstory `@fullstory/babel-plugin-react-native` babel plugin to 1.0.2, to better work around metro server issues.
 
 ## 1.0.4
 
-Updated the minimum versions for the FullStory babel plugins. Added a Typescript declaration for the FullStory base attributes. Added Typescript declarations for the FullStory API.
+Updated the minimum versions for the Fullstory babel plugins. Added a Typescript declaration for the Fullstory base attributes. Added Typescript declarations for the Fullstory API.
 
 ## 1.0.3
 
-Added the ability to invoke the `log` API from within React Native. See more information [here](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-FullStory-React-Native-Recording#01FM34C43RGW28NMC8PDWC7EZB)
+Added the ability to invoke the `log` API from within React Native. See more information [here](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-Fullstory-React-Native-Recording#01FM34C43RGW28NMC8PDWC7EZB)
 
 ## 1.0.2
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# FullStory React Native Plugin
+# Fullstory React Native Plugin
 
 [![CircleCI](https://circleci.com/gh/fullstorydev/fullstory-react-native.svg?style=svg)](https://circleci.com/gh/fullstorydev/fullstory-react-native)
 
-FullStory's React Native plugin exposes access to the FullStory Native Mobile SDK from within a React Native app. This plug-in is intended to be used in conjunction with [FullStory for Mobile Apps](https://www.fullstory.com/mobile-apps/).
+Fullstory's React Native plugin exposes access to the Fullstory Native Mobile SDK from within a React Native app. This plug-in is intended to be used in conjunction with [Fullstory for Mobile Apps](https://www.fullstory.com/mobile-apps/).
 
 ## Quick Links
 
-- [FullStory API](https://developer.fullstory.com)
+- [Fullstory API](https://developer.fullstory.com)
 - [Getting Started Guide](https://help.fullstory.com/hc/en-us/articles/360052419133)
 - [Email us](mailto:mobile-support@fullstory.com)
 
@@ -32,20 +32,20 @@ expo install @fullstory/react-native
 
 ## Configuring the babel plugin
 
-`@fullstory/babel-plugin-react-native` is automatically included as a dependency to the FullStory React Native plugin. Please refer to the babel plugin's [README.md](https://github.com/fullstorydev/fullstory-babel-plugin-react-native/blob/master/README.md) for information on how to configure it.
+`@fullstory/babel-plugin-react-native` is automatically included as a dependency to the Fullstory React Native plugin. Please refer to the babel plugin's [README.md](https://github.com/fullstorydev/fullstory-babel-plugin-react-native/blob/master/README.md) for information on how to configure it.
 
-`@fullstory/babel-plugin-annotate-react` is automatically included as a dependency to the FullStory React Native plugin. Please refer to the babel plugin's [README.md](https://github.com/fullstorydev/fullstory-babel-plugin-annotate-react/blob/master/README.md) for information on how to configure it for React Native.
+`@fullstory/babel-plugin-annotate-react` is automatically included as a dependency to the Fullstory React Native plugin. Please refer to the babel plugin's [README.md](https://github.com/fullstorydev/fullstory-babel-plugin-annotate-react/blob/master/README.md) for information on how to configure it for React Native.
 
 ## Importing the React Native plugin
 
-In order to use the FullStory Native Mobile SDK from within a React Native app, importing the React Native plugin is all that is required.
+In order to use the Fullstory Native Mobile SDK from within a React Native app, importing the React Native plugin is all that is required.
 
 ### Importing Example
 
 Here's an example of importing the SDK in a React Native app.
 
 ```JSX
-import FullStory from '@fullstory/react-native';
+import Fullstory from '@fullstory/react-native';
 ```
 
 ## Configuring for Expo
@@ -84,12 +84,12 @@ Plugins allow for extra customization by passing in an object with properties. I
 
 | Property          | Platform      | Required                               | Description                                                                                                                                                                                                                                                                                                       |
 | ----------------- | ------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| version           | Android & iOS | ✅                                     | FullStory for Mobile Apps plugin version.                                                                                                                                                                                                                                                                         |
+| version           | Android & iOS | ✅                                     | Fullstory for Mobile Apps plugin version.                                                                                                                                                                                                                                                                         |
 | org               | Android & iOS | ✅                                     | Your assigned organization ID.                                                                                                                                                                                                                                                                                    |
 | host              | Android & iOS | Optional. Defaults to: `fullstory.com` | The server url your sessions are sent to.                                                                                                                                                                                                                                                                         |
 | recordOnStart     | Android & iOS | Optional. Defaults to: `true`          | Setting RecordOnStart to `false` will prevent data capture until you explicitly invoke `FS.restart()` API.                                                                                                                                                                                                        |
 | additionalConfigs | Android & iOS | Optional. Defaults to: `nil`           | Pass additional configurations to [Android](https://help.fullstory.com/hc/en-us/articles/360040596093-Getting-Started-with-Android-Data-Capture#01F5E7XFMG19SNYS77NYETKDMQ) or [iOS](https://help.fullstory.com/hc/en-us/articles/360042772333-Getting-Started-with-iOS-Data-Capture#01FX61TBJ8FAD9CWBMY31DWSTH). |
-| enabledVariants   | Android       | Optional. Defaults to: `release`       | Specifies which variants to apply FullStory instrumentation.                                                                                                                                                                                                                                                      |
+| enabledVariants   | Android       | Optional. Defaults to: `release`       | Specifies which variants to apply Fullstory instrumentation.                                                                                                                                                                                                                                                      |
 | logLevel          | Android       | Optional. Defaults to: `info`          | Captures any log statements at or above the specified level.                                                                                                                                                                                                                                                      |
 | logcatLevel       | Android       | Optional. Defaults to: `off`           | Captures any Logcat messages at or above the specified level.                                                                                                                                                                                                                                                     |
 | includeAssets     | iOS           | Optional. Defaults to: `nil`           | Specify webview file types to upload for playback. This is strongly recommended if you intend to capture WebViews.                                                                                                                                                                                                |

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,33 +1,6 @@
 import { NativeModules } from 'react-native';
 import { jest } from '@jest/globals';
 
-// Mock getInternalInstanceHandleFromPublicInstance since the testing library doesn't provide it
-jest.mock(
-  'react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance',
-  () => {
-    const originalModule: any = jest.requireActual(
-      'react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance',
-    );
-
-    return {
-      ...originalModule,
-      getInternalInstanceHandleFromPublicInstance: jest.fn((element: any) => {
-        // Return a mock structure that includes currentProps from the element
-        if (element && element._reactInternals && element._reactInternals.memoizedProps) {
-          return {
-            stateNode: {
-              canonical: {
-                currentProps: element._reactInternals.memoizedProps,
-              },
-            },
-          };
-        }
-        return null;
-      }),
-    };
-  },
-);
-
 NativeModules.FullStory = {
   startPage: jest.fn(),
   endPage: jest.fn(),

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { render } from '@testing-library/react-native';
-import { Text, Platform, View } from 'react-native';
+import { Platform } from 'react-native';
 import { jest } from '@jest/globals';
-import { applyFSPropertiesWithRef } from '../index';
+import { applyFSPropertiesToInstance } from '../index';
 
 declare global {
   var __turboModuleProxy: unknown;
@@ -33,7 +32,7 @@ const fsTagNameValue = 'custom-text-element';
 const fsClassValue = 'custom-text-class';
 const fsAttributeValue = { color: 'red' };
 
-describe('Reading FS properties on iOS', () => {
+describe('FS properties on iOS New Architecture', () => {
   beforeAll(() => {
     originalPlatformOS = Platform.OS;
     global.__turboModuleProxy = jest.fn(() => ({}));
@@ -55,104 +54,60 @@ describe('Reading FS properties on iOS', () => {
     });
   });
 
-  it('Reads fs properties correctly', () => {
-    const TestComponent = () => {
-      return (
-        <Text fsTagName={fsTagNameValue} fsClass={fsClassValue} fsAttribute={fsAttributeValue}>
-          Test Title
-        </Text>
-      );
-    };
+  describe('applyFSPropertiesToInstance', () => {
+    const instance = {} as any;
 
-    render(<TestComponent />);
-
-    // All properties should be batched into a single setBatchProperties call
-    expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({
+    it('batches all fs* and data* properties into a single command', () => {
+      applyFSPropertiesToInstance(instance, {
         fsTagName: fsTagNameValue,
         fsClass: fsClassValue,
         fsAttribute: fsAttributeValue,
-      }),
-    );
-    expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledTimes(1);
-  });
-
-  it('Annotate plugin annotates correctly', () => {
-    const TestComponent = () => {
-      return <Text>Test Title</Text>;
-    };
-    render(<TestComponent />);
-
-    // All properties should be batched into a single setBatchProperties call
-    expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({
         dataElement: 'Text',
         dataComponent: 'TestComponent',
         dataSourceFile: 'index.test.tsx',
-      }),
-    );
-    expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledTimes(1);
-  });
+      });
 
-  it('Handles existing ref objects correctly', () => {
-    const ref = React.createRef<View>();
-    render(<View ref={ref} fsTagName={fsTagNameValue} />);
-    expect(ref.current).toBeDefined();
-    expect((ref.current as any)?._reactInternals?.type).toBe(View);
-    expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({
+      expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledWith(instance, {
         fsTagName: fsTagNameValue,
-      }),
-    );
-    expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledTimes(1);
-  });
+        fsClass: fsClassValue,
+        fsAttribute: fsAttributeValue,
+        dataElement: 'Text',
+        dataComponent: 'TestComponent',
+        dataSourceFile: 'index.test.tsx',
+      });
+      expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledTimes(1);
+    });
 
-  it('Handles existing ref functions correctly', () => {
-    const ref = jest.fn<(element: View) => void>();
-    render(<View ref={ref} fsTagName={fsTagNameValue} />);
-    expect(ref).toHaveBeenCalledWith(expect.any(Object));
-    expect((ref.mock.calls[0][0] as any)?._reactInternals?.type).toBe(View);
-    expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({
-        fsTagName: fsTagNameValue,
-      }),
-    );
-    expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledTimes(1);
-  });
+    it('only forwards recognized, correctly-typed properties', () => {
+      applyFSPropertiesToInstance(instance, {
+        fsClass: fsClassValue,
+        fsTagName: 123,
+        somethingElse: 'ignored',
+      } as Record<string, unknown>);
 
-  it('Calls Native Command once even if double wrapped', () => {
-    render(<View ref={applyFSPropertiesWithRef()} fsTagName={fsTagNameValue} />);
-    expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({
-        fsTagName: fsTagNameValue,
-      }),
-    );
-    expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledTimes(1);
-  });
+      expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledWith(instance, {
+        fsClass: fsClassValue,
+      });
+      expect(mockNativeCommands.setBatchProperties).toHaveBeenCalledTimes(1);
+    });
 
-  it('ref object is set to null when component unmounts', () => {
-    const ref = React.createRef<View>();
-    const { unmount } = render(<View ref={ref} fsTagName={fsTagNameValue} />);
-    expect(ref.current).not.toBeNull();
-    unmount();
-    expect(ref.current).toBeNull();
-  });
+    it('does not dispatch when there are no FS properties', () => {
+      applyFSPropertiesToInstance(instance, { somethingElse: 'ignored' });
+      expect(mockNativeCommands.setBatchProperties).not.toHaveBeenCalled();
+    });
 
-  it('ref callback is called with null when component unmounts', () => {
-    const ref = jest.fn<(element: View | null) => void>();
-    const { unmount } = render(<View ref={ref} fsTagName={fsTagNameValue} />);
-    expect(ref).toHaveBeenCalledWith(expect.any(Object));
-    unmount();
-    expect(ref).toHaveBeenLastCalledWith(null);
-  });
+    it('no-ops when the instance or props is missing', () => {
+      applyFSPropertiesToInstance(null, { fsClass: fsClassValue });
+      applyFSPropertiesToInstance(instance, null);
+      applyFSPropertiesToInstance(instance, undefined);
+      expect(mockNativeCommands.setBatchProperties).not.toHaveBeenCalled();
+    });
 
-  it('component without FS attributes does not trigger setBatchProperties', () => {
-    render(<View />);
-    expect(mockNativeCommands.setBatchProperties).not.toHaveBeenCalled();
+    it('does not dispatch when not on iOS', () => {
+      Object.defineProperty(Platform, 'OS', { writable: true, value: 'android' });
+      applyFSPropertiesToInstance(instance, { fsClass: fsClassValue });
+      Object.defineProperty(Platform, 'OS', { writable: true, value: 'ios' });
+      expect(mockNativeCommands.setBatchProperties).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Platform } from 'react-native';
 import { jest } from '@jest/globals';
 import { applyFSPropertiesToInstance } from '../index';

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,22 +125,22 @@ export function applyFSPropertiesToInstance(
 
   const { fsClass, fsAttribute, fsTagName, dataElement, dataComponent, dataSourceFile } = props;
 
-  if (typeof fsClass === 'string') {
+  if (fsClass && typeof fsClass === 'string') {
     batchedProps.fsClass = fsClass;
   }
   if (fsAttribute && typeof fsAttribute === 'object') {
     batchedProps.fsAttribute = fsAttribute;
   }
-  if (typeof fsTagName === 'string') {
+  if (fsTagName && typeof fsTagName === 'string') {
     batchedProps.fsTagName = fsTagName;
   }
-  if (typeof dataElement === 'string') {
+  if (dataElement && typeof dataElement === 'string') {
     batchedProps.dataElement = dataElement;
   }
-  if (typeof dataComponent === 'string') {
+  if (dataComponent && typeof dataComponent === 'string') {
     batchedProps.dataComponent = dataComponent;
   }
-  if (typeof dataSourceFile === 'string') {
+  if (dataSourceFile && typeof dataSourceFile === 'string') {
     batchedProps.dataSourceFile = dataSourceFile;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import { HostComponent, NativeModules, Platform } from 'react-native';
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
-import { ComponentRef, ForwardedRef } from 'react';
+import { ComponentRef } from 'react';
 import type { FSSessionData } from './NativeFullStory';
 import {
   FullstoryStatic,
@@ -87,13 +87,15 @@ declare type FullStoryPrivateStatic = {
 const identifyWithProperties = (uid: string, userVars = {}) => identify(uid, userVars);
 
 export { FSPage } from './FSPage';
+
 type FSComponentType = HostComponent<NativeProps>;
+type FSNativeInstance = ComponentRef<FSComponentType>;
 
 interface NativeCommands {
-  setBatchProperties: (viewRef: ComponentRef<FSComponentType>, props: object) => void;
+  setBatchProperties: (viewRef: FSNativeInstance, props: object) => void;
 }
 
-/* 
+/*
   Batching all property commands into a single native call to reduce the window for race conditions
   with React Native's rendering scheduler.
 */
@@ -101,117 +103,51 @@ const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['setBatchProperties'],
 });
 
-let getInternalInstanceHandleFromPublicInstance: Function | undefined;
-
-try {
-  // This import confuses the metro resolver in earlier versions of react-native.
-  getInternalInstanceHandleFromPublicInstance =
-    require('react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance').getInternalInstanceHandleFromPublicInstance;
-} catch (e) {}
-
-export const FS_REF_SYMBOL = Symbol('fullstory.ref');
-
-type MaybeFSForwardedRef<T> = ForwardedRef<T> & {
-  [FS_REF_SYMBOL]?: boolean;
-};
-
-type FSNativeElement = ComponentRef<FSComponentType> & {
-  currentProps?: Record<string, unknown>;
-};
-
-// Shared wrapper for components without refs (most common case)
-function sharedRefWrapper(element: FSNativeElement | null) {
-  if (element && isTurboModuleEnabled && Platform.OS === 'ios' && !Platform.isTV) {
-    let currentProps: Record<string, unknown> | undefined;
-
-    if (getInternalInstanceHandleFromPublicInstance) {
-      currentProps =
-        getInternalInstanceHandleFromPublicInstance(element)?.stateNode?.canonical.currentProps;
-    } else {
-      currentProps = element.currentProps;
-    }
-    if (currentProps) {
-      const batchedProps: Partial<Record<SupportedFSAttributes, string | object>> = {};
-
-      const fsClass = currentProps.fsClass;
-      if (fsClass && typeof fsClass === 'string') {
-        batchedProps.fsClass = fsClass;
-      }
-
-      const fsAttribute = currentProps.fsAttribute;
-      if (fsAttribute && typeof fsAttribute === 'object') {
-        batchedProps.fsAttribute = fsAttribute;
-      }
-
-      const fsTagName = currentProps.fsTagName;
-      if (fsTagName && typeof fsTagName === 'string') {
-        batchedProps.fsTagName = fsTagName;
-      }
-
-      const dataElement = currentProps.dataElement;
-      if (dataElement && typeof dataElement === 'string') {
-        batchedProps.dataElement = dataElement;
-      }
-
-      const dataComponent = currentProps.dataComponent;
-      if (dataComponent && typeof dataComponent === 'string') {
-        batchedProps.dataComponent = dataComponent;
-      }
-
-      const dataSourceFile = currentProps.dataSourceFile;
-      if (dataSourceFile && typeof dataSourceFile === 'string') {
-        batchedProps.dataSourceFile = dataSourceFile;
-      }
-
-      // Send all properties as a single batched command
-      if (Object.keys(batchedProps).length > 0) {
-        Commands.setBatchProperties(element, batchedProps);
-      }
-    }
-  }
-}
-
-Object.defineProperty(sharedRefWrapper, FS_REF_SYMBOL, {
-  value: true,
-  enumerable: false,
-  writable: false,
-  configurable: false,
-});
-
-export function applyFSPropertiesWithRef(
-  existingRef?: MaybeFSForwardedRef<FSNativeElement>,
-  hasDynamicAttributes = true,
+/**
+ * Applies FullStory properties to an already-committed native instance by
+ * dispatching a single batched native command. Invoked by the FullStory babel
+ * plugin's Fabric commit-phase hook with the host component's public instance
+ * and its committed props. iOS New Architecture only; on the old architecture
+ * the regular view-manager prop pipeline applies these props instead.
+ */
+export function applyFSPropertiesToInstance(
+  instance: FSNativeInstance | null | undefined,
+  props: Record<string, unknown> | null | undefined,
 ) {
-  // Return early if already wrapped
-  if (existingRef && existingRef[FS_REF_SYMBOL]) {
-    return existingRef;
+  if (!instance || !props) {
+    return;
+  }
+  if (!(isTurboModuleEnabled && Platform.OS === 'ios' && !Platform.isTV)) {
+    return;
   }
 
-  // Use shared wrapper for null/undefined refs or static attributes
-  if (!existingRef && !hasDynamicAttributes) {
-    return sharedRefWrapper;
+  const batchedProps: Partial<Record<SupportedFSAttributes, string | object>> = {};
+
+  const { fsClass, fsAttribute, fsTagName, dataElement, dataComponent, dataSourceFile } = props;
+
+  if (typeof fsClass === 'string') {
+    batchedProps.fsClass = fsClass;
+  }
+  if (fsAttribute && typeof fsAttribute === 'object') {
+    batchedProps.fsAttribute = fsAttribute;
+  }
+  if (typeof fsTagName === 'string') {
+    batchedProps.fsTagName = fsTagName;
+  }
+  if (typeof dataElement === 'string') {
+    batchedProps.dataElement = dataElement;
+  }
+  if (typeof dataComponent === 'string') {
+    batchedProps.dataComponent = dataComponent;
+  }
+  if (typeof dataSourceFile === 'string') {
+    batchedProps.dataSourceFile = dataSourceFile;
   }
 
-  function refWrapper(element: FSNativeElement | null) {
-    sharedRefWrapper(element);
-
-    if (existingRef) {
-      if (typeof existingRef === 'function') {
-        existingRef(element);
-      } else {
-        existingRef.current = element;
-      }
-    }
+  // Send all properties as a single batched command.
+  if (Object.keys(batchedProps).length > 0) {
+    Commands.setBatchProperties(instance, batchedProps);
   }
-
-  Object.defineProperty(refWrapper, FS_REF_SYMBOL, {
-    value: true,
-    enumerable: false,
-    writable: false,
-    configurable: false,
-  });
-
-  return refWrapper;
 }
 
 const FullstoryAPI: FullstoryStatic = {


### PR DESCRIPTION
Stacked with https://github.com/fullstorydev/fullstory-babel-plugin-react-native/pull/72

The previous approach to delivering FS attributes (`fsClass, fsAttribute, fsTagName, dataElement, dataComponent, dataSourceFile`) on the New Architecture worked by intercepting React element creation and replacing every element's `ref` with a wrapper function (`applyFSPropertiesWithRef`) that dispatched a `setBatchProperties` native command when React attached the ref during the layout phase.

This PR replaces that mechanism entirely with a Fabric renderer commit-phase hook.

### Changes

Not much changed in this PR. `applyFSPropertiesToInstance` behaves similarly to `applyFSPropertiesWithRef` in that it calls our native command to pass FS properties. It no longer needs to act as a wrapper to a `ref` object.

Since we are no longer wrapping `refs` we can remove some of the tests involves `refs`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how FS attributes reach native views on iOS Fabric and depends on the paired babel plugin commit hook; misalignment could break capture or ref behavior, though old architecture still uses the view-manager path.
> 
> **Overview**
> On **iOS New Architecture**, Fullstory attribute delivery no longer rewrites element `ref`s with `applyFSPropertiesWithRef`. The public API is now **`applyFSPropertiesToInstance`**, which the babel plugin’s Fabric **commit-phase** hook calls with the committed host instance and props; it still batches `fs*` / `data*` fields into one `setBatchProperties` native command (same gating: turbo modules, iOS, non-TV).
> 
> Implementation drops ref-wrapper machinery (`FS_REF_SYMBOL`, `sharedRefWrapper`, `getInternalInstanceHandleFromPublicInstance` / Fabric public-instance reads). Tests target the new function directly and drop render/ref/unmount coverage; **`setupTests`** no longer mocks `ReactFabricPublicInstance`.
> 
> **README** and **CHANGELOG** normalize product spelling to “Fullstory” (including import example `Fullstory` from `@fullstory/react-native`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829f4e5f5b44c88dbfa42d1088b2eb4f58a48b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->