### PR TITLE
register session listener in initialize() not constructor

### DIFF
--- a/android/src/turbo/java/com/FullStoryModule.java
+++ b/android/src/turbo/java/com/FullStoryModule.java
@@ -9,6 +9,11 @@ public class FullStoryModule extends NativeFullStorySpec {
 
     FullStoryModule(ReactApplicationContext context) {
         super(context);
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
         FullStoryModuleImpl.initSessionListener(
             sessionData -> emitOnSessionStarted(sessionData)
         );


### PR DESCRIPTION
### Problem

Apps using the New Architecture could crash with a native `SIGSEGV` on the main thread during app launch when FullStory was enabled. The crash appeared in `JavaTurboModule::configureEventEmitterCallback` in `libreactnative.so`.

The FullStoryModule constructor (added in `1.9.0`) immediately registered a session-ready listener with the FullStory SDK:

```
FullStoryModule(ReactApplicationContext context) {
    super(context);
    FullStoryModuleImpl.initSessionListener(
        sessionData -> emitOnSessionStarted(sessionData)
    );
}
```

With `recordOnStart=false` + `FS.restart()`, there's a possibility that `emitOnSessionStarted` is called during the React Native JS bridge teardown and rebuild that happens during Activity recreation, which causes a crash. 

With `recordOnStart=true`, a session starts before React Native module exists, so `emitOnSessionStarted` is never called, which is why this crash wasn't observed.

### Fix
Move `initSessionListener` from the constructor to `initialize()`, which React Native's TurboModuleManager guarantees is called after the module is fully set up. React Native's TurboModuleManager guarantees `initialize()` is called after the event emitter is wired up, making it the correct place to register callbacks that may fire immediately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Android TurboModule lifecycle change with a clear crash fix; legacy module path is unchanged.
> 
> **Overview**
> Fixes a **New Architecture launch crash** (`SIGSEGV` in `JavaTurboModule::configureEventEmitterCallback`) by changing **when** the turbo `FullStoryModule` wires up the FullStory session callback.
> 
> **`FullStoryModuleImpl.initSessionListener`** (which can immediately invoke **`emitOnSessionStarted`**) is **removed from the constructor** and **registered in an overridden `initialize()`** after `super.initialize()`. That aligns listener registration with TurboModuleManager’s post-setup lifecycle so the event emitter is ready before any session-ready callback fires—especially relevant when **`recordOnStart=false`** and **`FS.restart()`** can trigger events during Activity/bridge recreation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cc70516064b6f5143c11a71fe3d947894f32f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->