### PR TITLE
Release 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.10.1
+
+Android: Fixed a crash that occurred on the New Architecture when a FullStory session became ready before the TurboModule event emitter was initialized.
+
 ## 1.10.0
 
 iOS New Architecture: replaced ref rewriting with applyFSPropertiesToInstance, a new function invoked directly by the Fullstory babel plugin's Fabric commit-phase hook.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/react-native",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "~2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "The official FullStory React Native plugin",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog-only release with no source changes in this diff; documented fix is a targeted Android startup race fix.
> 
> **Overview**
> **Release 1.10.1** bumps `@fullstory/react-native` from **1.10.0** to **1.10.1** in `package.json` and `package-lock.json`.
> 
> The **CHANGELOG** adds a **1.10.1** entry documenting an **Android New Architecture** fix: a crash when a FullStory session became ready **before** the TurboModule event emitter was initialized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2deb6a73c6c62da6c4a9c959c2b838628f42059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->