### PR TITLE
fix(android): unregister FS listener on TurboModule invalidation

### DIFF
--- a/android/src/main/java/com/fullstory/reactnative/FullStoryModuleImpl.java
+++ b/android/src/main/java/com/fullstory/reactnative/FullStoryModuleImpl.java
@@ -95,6 +95,19 @@ public class FullStoryModuleImpl {
         });
     }
 
+    /**
+     * Called when the React Native module is invalidated (e.g. the ReactHost/bridge is being
+     * destroyed during Activity recreation or reload). Unregisters the FullStory ready listener so
+     * that a session-ready callback can never fire against a destroyed module instance, and drops
+     * any pending onReady promises.
+     */
+    public static void tearDownSessionListener() {
+        FS.setReadyListener(null);
+        synchronized (pendingOnReadyPromises) {
+            pendingOnReadyPromises.clear();
+        }
+    }
+
     public static void onReady(Promise promise) {
         if (promise == null) {
             return;

--- a/android/src/turbo/java/com/FullStoryModule.java
+++ b/android/src/turbo/java/com/FullStoryModule.java
@@ -7,6 +7,14 @@ import com.facebook.react.bridge.ReadableMap;
 
 public class FullStoryModule extends NativeFullStorySpec {
 
+    /**
+     * Guards emitOnSessionStarted against module invalidation. The FullStory SDK dispatches
+     * session-ready callbacks asynchronously on the main thread, so a callback can arrive while
+     * (or after) React Native tears down this module and its JS runtime.
+     */
+    private final Object emitLock = new Object();
+    private boolean invalidated = false;
+
     FullStoryModule(ReactApplicationContext context) {
         super(context);
     }
@@ -14,9 +22,25 @@ public class FullStoryModule extends NativeFullStorySpec {
     @Override
     public void initialize() {
         super.initialize();
-        FullStoryModuleImpl.initSessionListener(
-            sessionData -> emitOnSessionStarted(sessionData)
-        );
+        FullStoryModuleImpl.initSessionListener(sessionData -> {
+            synchronized (emitLock) {
+                if (invalidated) {
+                    // The module was torn down after this callback was queued; the event
+                    // emitter is no longer safe to touch.
+                    return;
+                }
+                emitOnSessionStarted(sessionData);
+            }
+        });
+    }
+
+    @Override
+    public void invalidate() {
+        synchronized (emitLock) {
+            invalidated = true;
+        }
+        FullStoryModuleImpl.tearDownSessionListener();
+        super.invalidate();
     }
 
     @Override


### PR DESCRIPTION
## Problem
Thread: https://fullstory.slack.com/archives/C1DAWDPM3/p1783353869346629

The FS SDK dispatches session-ready callbacks asynchronously https://github.com/cowpaths/mn/blob/73d5e14144a0d346b585a517cfac6ed378d3eb42/projects/fullstory/nativemobile/android/adk/impl/src/main/java/com/fullstory/instrumentation/InstrumentInjectorBridgeImpl.java#L354-L368. 

On ReactHost reload the JavaTurboModule C++ object is destroyed before the queued main-thread callback fires, causing a use-after-free `SIGSEGV`.

This crash is reproduced in https://github.com/cowpaths/mn/pull/108253

## Fix 
Override `invalidate()` in the turbo FullStoryModule to call `tearDownSessionListener()`, which calls `FS.setReadyListener(null)` to remove the listener from the SDK's static `statusListeners` list and silently drops any pending `onReady` promises. The turbo module also guards `emitOnSessionStarted` behind an invalidated flag checked under `emitLock`, catching any callback that was already queued before `invalidate()` ran.

Verified by reproducing the identical SIGSEGV in the test app and confirming clean reload after this fix.

Tested on React Native New Architecture and React Native 66 old architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native bridge lifecycle and async SDK callbacks; incorrect teardown could drop session events, but scope is limited to reload/invalidation paths and reduces crash risk.
> 
> **Overview**
> Fixes a **SIGSEGV use-after-free** when React Native tears down the TurboModule during **ReactHost reload** while the FullStory SDK still has a **session-ready callback** queued on the main thread.
> 
> **`FullStoryModuleImpl`** adds **`tearDownSessionListener()`**, which calls **`FS.setReadyListener(null)`** and clears pending **`onReady`** promises so callbacks cannot run against a dead module.
> 
> The **turbo `FullStoryModule`** now overrides **`invalidate()`** to set an **`invalidated`** flag (under **`emitLock`**), invoke teardown, then call **`super.invalidate()`**. **`emitOnSessionStarted`** is only emitted when the module is still valid, covering callbacks queued just before invalidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2305d458ac016391d591e8e2ffa87247bb69eb67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->