### PR TITLE
skip 32-bit TurboModule emitter on affected RN versions

### DIFF
--- a/android/src/turbo/java/com/FullStoryModule.java
+++ b/android/src/turbo/java/com/FullStoryModule.java
@@ -28,6 +28,8 @@ public class FullStoryModule extends NativeFullStorySpec {
          * Since SIGSEGV cannot be caught in Java, skip the listener on affected 32-bit builds.
          */
         if (!android.os.Process.is64Bit() && !isTurboEventEmitterSafe()) {
+            // Pass null so that no event is emitted, matching the legacy module's behaviour on this path.
+            FullStoryModuleImpl.initSessionListener(null);
             return;
         }
         FullStoryModuleImpl.initSessionListener(sessionData -> {

--- a/android/src/turbo/java/com/FullStoryModule.java
+++ b/android/src/turbo/java/com/FullStoryModule.java
@@ -22,6 +22,14 @@ public class FullStoryModule extends NativeFullStorySpec {
     @Override
     public void initialize() {
         super.initialize();
+        /**
+         * JavaTurboModule's event-emitter callback has a null-pointer crash on 32-bit Android
+         * processes across several RN versions
+         * Since SIGSEGV cannot be caught in Java, skip the listener on affected 32-bit builds.
+         */
+        if (!android.os.Process.is64Bit() && !isTurboEventEmitterSafe()) {
+            return;
+        }
         FullStoryModuleImpl.initSessionListener(sessionData -> {
             synchronized (emitLock) {
                 if (invalidated) {
@@ -32,6 +40,33 @@ public class FullStoryModule extends NativeFullStorySpec {
                 emitOnSessionStarted(sessionData);
             }
         });
+    }
+
+    /**
+     * Returns true if the running React Native version has the fix for the 32-bit
+     * TurboModule event-emitter crash https://github.com/react/react-native/issues/51628
+
+     * Falls back to true if the version cannot be determined, since an inaccessible
+     * ReactNativeVersion implies a future RN version that already has the fix.
+     */
+    private static boolean isTurboEventEmitterSafe() {
+        try {
+            java.lang.reflect.Field field =
+                Class.forName("com.facebook.react.modules.systeminfo.ReactNativeVersion")
+                     .getField("VERSION");
+            @SuppressWarnings("unchecked")
+            java.util.Map<String, Object> v = (java.util.Map<String, Object>) field.get(null);
+            int major = (int) v.get("major");
+            int minor = (int) v.get("minor");
+            int patch = (int) v.get("patch");
+            // Fixed in: 0.79.6, 0.80.1, 0.81.0+
+            return major > 0
+                || minor >= 81
+                || (minor == 80 && patch >= 1)
+                || (minor == 79 && patch >= 6);
+        } catch (Exception e) {
+            return true;
+        }
     }
 
     @Override


### PR DESCRIPTION
Relevant thread: https://fullstory.slack.com/archives/C1DAWDPM3/p1784728972060599

## Problem

On 32-bit Android processes, several React Native versions have a
null-pointer crash inside JavaTurboModule's event-emitter callback
([react-native#51628](https://github.com/react/react-native/issues/51628)). The crash manifests as a `SIGSEGV`, which cannot
be caught in Java, making it fatal.

## Solution

In `FullStoryModule.initialize()`, skip registering the session-ready
listener when both conditions are true:
- the process is 32-bit
- the running RN version is known to be affected (< 0.79.6, < 0.80.1,
  or < 0.81.0)
The version check uses reflection against `com.facebook.react.modules.systeminfo.ReactNativeVersion`, which has
been generated at build time by the RN Gradle plugin since early RN
versions. If the class is unreachable (e.g. a future RN that moved or
removed it), the check falls back to `true` — meaning we assume the fix
is present — rather than silently disabling the emitter on a version
that almost certainly already includes the fix.

## Affected versions
| RN series | Fixed in |
|-----------|----------|
| 0.79.x    | 0.79.6   |
| 0.80.x    | 0.80.1   |
| 0.81+     | all      |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes native module initialization and disables `onSessionStarted` events on a specific 32-bit + RN version matrix; low blast radius but affects session-ready JS integration on those devices.
> 
> **Overview**
> Avoids a fatal **SIGSEGV** on **32-bit Android** when the TurboModule path would emit `onSessionStarted` on React Native builds affected by [react-native#51628](https://github.com/react/react-native/issues/51628).
> 
> In `FullStoryModule.initialize()`, the session listener is only registered when the process is **64-bit** or `isTurboEventEmitterSafe()` reports a fixed RN version (≥ 0.79.6, ≥ 0.80.1, or ≥ 0.81.0). Otherwise it calls `FullStoryModuleImpl.initSessionListener(null)`, aligning with the legacy module so **no JS event is emitted** on that path.
> 
> `isTurboEventEmitterSafe()` reads `ReactNativeVersion.VERSION` via reflection; if that fails, it assumes the fix is present so future RN versions are not silently stripped of session events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60765fe0ad7192dcce728e2ef90adbb9b328041c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->