### PR TITLE
32 bit event emitter refactor

### DIFF
--- a/android/src/turbo/java/com/FullStoryModule.java
+++ b/android/src/turbo/java/com/FullStoryModule.java
@@ -4,16 +4,16 @@ import androidx.annotation.NonNull;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 public class FullStoryModule extends NativeFullStorySpec {
 
     /**
-     * Guards emitOnSessionStarted against module invalidation. The FullStory SDK dispatches
+     * Guards the DeviceEventEmitter call against module invalidation. The FullStory SDK dispatches
      * session-ready callbacks asynchronously on the main thread, so a callback can arrive while
      * (or after) React Native tears down this module and its JS runtime.
      */
-    private final Object emitLock = new Object();
-    private boolean invalidated = false;
+    private volatile boolean invalidated = false;
 
     FullStoryModule(ReactApplicationContext context) {
         super(context);
@@ -23,22 +23,18 @@ public class FullStoryModule extends NativeFullStorySpec {
     public void initialize() {
         super.initialize();
         FullStoryModuleImpl.initSessionListener(sessionData -> {
-            synchronized (emitLock) {
-                if (invalidated) {
-                    // The module was torn down after this callback was queued; the event
-                    // emitter is no longer safe to touch.
-                    return;
-                }
-                emitOnSessionStarted(sessionData);
+            if (invalidated) {
+                return;
             }
+            getReactApplicationContext()
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit("fsOnSessionStarted", sessionData);
         });
     }
 
     @Override
     public void invalidate() {
-        synchronized (emitLock) {
-            invalidated = true;
-        }
+        invalidated = true;
         FullStoryModuleImpl.tearDownSessionListener();
         super.invalidate();
     }

--- a/android/src/turbo/java/com/FullStoryModule.java
+++ b/android/src/turbo/java/com/FullStoryModule.java
@@ -13,7 +13,8 @@ public class FullStoryModule extends NativeFullStorySpec {
      * session-ready callbacks asynchronously on the main thread, so a callback can arrive while
      * (or after) React Native tears down this module and its JS runtime.
      */
-    private volatile boolean invalidated = false;
+    private final Object emitLock = new Object();
+    private boolean invalidated = false;
 
     FullStoryModule(ReactApplicationContext context) {
         super(context);
@@ -23,18 +24,24 @@ public class FullStoryModule extends NativeFullStorySpec {
     public void initialize() {
         super.initialize();
         FullStoryModuleImpl.initSessionListener(sessionData -> {
-            if (invalidated) {
-                return;
+            synchronized (emitLock) {
+                if (invalidated) {
+                    // The module was torn down after this callback was queued; the event
+                    // emitter is no longer safe to touch.
+                    return;
+                }
+                getReactApplicationContext()
+                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit("fsOnSessionStarted", sessionData);
             }
-            getReactApplicationContext()
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit("fsOnSessionStarted", sessionData);
         });
     }
 
     @Override
     public void invalidate() {
-        invalidated = true;
+        synchronized (emitLock) {
+            invalidated = true;
+        }
         FullStoryModuleImpl.tearDownSessionListener();
         super.invalidate();
     }

--- a/ios/FullStory.h
+++ b/ios/FullStory.h
@@ -1,4 +1,4 @@
-#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 #import <FullStory/FS.h>
 #import <FullStory/FSDelegate.h>
 
@@ -7,13 +7,13 @@
 #endif
 
 #ifdef RCT_NEW_ARCH_ENABLED
-@interface FullStory : NativeFullStorySpecBase <FSDelegate>
+@interface FullStory : RCTEventEmitter <NativeFullStorySpec, FSDelegate>
 @end
 
 @interface FullStoryPrivate : NativeFullStoryPrivateSpecBase <FSDelegate>
 @end
 #else
-@interface FullStory : NSObject <RCTBridgeModule, FSDelegate>
+@interface FullStory : RCTEventEmitter <FSDelegate>
 @end
 
 @interface FullStoryPrivate : NSObject <RCTBridgeModule, FSDelegate>
@@ -25,11 +25,3 @@
 + (void) _updatePageWithNonce:(NSUUID *)nonce properties:(NSDictionary<NSString *, id> *)properties;
 + (void) _endPageWithNonce:(NSUUID *)nonce;
 @end
-
-#ifdef RCT_NEW_ARCH_ENABLED
-@interface FullStory () <NativeFullStorySpec>
-@end
-
-@interface FullStoryPrivate () <NativeFullStoryPrivateSpec>
-@end
-#endif

--- a/ios/FullStory.h
+++ b/ios/FullStory.h
@@ -25,3 +25,10 @@
 + (void) _updatePageWithNonce:(NSUUID *)nonce properties:(NSDictionary<NSString *, id> *)properties;
 + (void) _endPageWithNonce:(NSUUID *)nonce;
 @end
+
+#ifdef RCT_NEW_ARCH_ENABLED
+@interface FullStory () <NativeFullStorySpec>
+@end
+@interface FullStoryPrivate () <NativeFullStoryPrivateSpec>
+@end
+#endif

--- a/ios/FullStory.mm
+++ b/ios/FullStory.mm
@@ -26,6 +26,13 @@ NSString *const PagesAPIError = @"Unable to access native FullStory pages API an
 
 RCT_EXPORT_MODULE()
 
+- (NSArray<NSString *> *)supportedEvents {
+    return @[@"fsOnSessionStarted"];
+}
+
+- (void)startObserving {}
+- (void)stopObserving {}
+
 RCT_EXPORT_METHOD(anonymize)
 {
   dispatch_async(dispatch_get_main_queue(), ^{
@@ -199,13 +206,11 @@ RCT_EXPORT_METHOD(updatePage:(NSString *)nonce pageProperties:(NSDictionary *)pa
         [self resolveOnReadyPromisesWithURL:sessionUrl];
     }
 
-#ifdef RCT_NEW_ARCH_ENABLED
-    [self emitOnSessionStarted:@{
+    [self sendEventWithName:@"fsOnSessionStarted" body:@{
         @"replayStartUrl": sessionUrl,
         @"replayNowUrl": [FS currentSessionURL: true] ?: @"",
         @"sessionId": FS.currentSession ?: @"",
     }];
-#endif
 }
 
 - (void) onReady:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {

--- a/ios/FullStory.mm
+++ b/ios/FullStory.mm
@@ -14,7 +14,7 @@
 }
 
 - (instancetype)init {
-    self = [super init];
+    self = [super initWithDisabledObservation];
     if (self) {
         FS.delegate = self;
         onReadyPromises = [NSMutableArray new];
@@ -29,9 +29,6 @@ RCT_EXPORT_MODULE()
 - (NSArray<NSString *> *)supportedEvents {
     return @[@"fsOnSessionStarted"];
 }
-
-- (void)startObserving {}
-- (void)stopObserving {}
 
 RCT_EXPORT_METHOD(anonymize)
 {

--- a/src/NativeFullStory.ts
+++ b/src/NativeFullStory.ts
@@ -1,6 +1,5 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
-import type { EventEmitter } from 'react-native/Libraries/Types/CodegenTypes';
 
 // needs to be defined here, cannot be imported
 export type FSSessionData = {
@@ -25,10 +24,6 @@ export interface Spec extends TurboModule {
   startPage(nonce: string, pageName: string, pageProperties?: Object): void;
   endPage(uuid: string): void;
   updatePage(uuid: string, pageProperties: Object): void;
-  // Not exposed in the public API. Must be declared here because TurboModule codegen
-  // requires all native event emitters to be defined on the Spec interface. Used
-  // internally by onReady() to support the listener-based overload.
-  readonly onSessionStarted: EventEmitter<FSSessionData>;
 }
 
 export default TurboModuleRegistry.get<Spec>('FullStory');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // When adding new imports, please verify that they are not causing the metro resolver to fail in earlier versions of react-native.
-import { HostComponent, NativeModules, Platform } from 'react-native';
+import { DeviceEventEmitter, HostComponent, NativeModules, Platform } from 'react-native';
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import { ComponentRef } from 'react';
@@ -42,7 +42,6 @@ const {
   restart = () => null,
   log = () => null,
   resetIdleTimer = () => null,
-  onSessionStarted = () => ({ remove: () => null }),
 } = FullStory ?? {};
 
 function onReady(): Promise<FSSessionData>;
@@ -68,7 +67,7 @@ function onReady(
     }
   });
 
-  return onSessionStarted(listener);
+  return DeviceEventEmitter.addListener('fsOnSessionStarted', listener);
 }
 
 const FullStoryPrivate = isTurboModuleEnabled


### PR DESCRIPTION
Relevant thread: https://fullstory.slack.com/archives/C1DAWDPM3/p1784728972060599

## Problem
On 32-bit Android processes, several React Native versions have a
null-pointer crash inside JavaTurboModule's event-emitter callback
(https://github.com/react/react-native/issues/51628). The crash manifests as a SIGSEGV, which cannot
be caught in Java, making it fatal.

This is my 2nd attempt at fixing, first try here: https://github.com/fullstorydev/fullstory-react-native/pull/156

## Solution

Remove the `EventEmitter` and replace with legacy `DeviceEventEmitter.addListener` API. No change to the public API. The `onReady(listener)` overload signature and return type are unchanged. The `onReady()` Promise overload is unaffected.

This PR replaces the codegen emitter with `DeviceEventEmitter.addListener` / `RCTDeviceEventEmitter.emit`, which has been available since React Native's initial release and is unaffected by the 32-bit issue. This is intentionally the legacy path — once our minimum supported React Native version is raised past 0.79.6 (which carries the 32-bit fix), we can revert to the codegen `EventEmitter<T>` on the spec.

Tested on RN 78 old & new architecture, RN 86 new architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fbecdba358436388e7f7b52479a0ecccefa9f0ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->