### PR TITLE
Release 1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.10.2
+
+Android: Fixed a crash on the New Architecture where a FullStory session-ready callback could fire against a destroyed TurboModule after the React host was torn down.
+
+Android and iOS: Replaced the TurboModule event emitter with DeviceEventEmitter, fixing compatibility on 32-bit devices and enabling the `onReady` callback on the Old Architecture.
+
 ## 1.10.1
 
 Android: Fixed a crash that occurred on the New Architecture when a FullStory session became ready before the TurboModule event emitter was initialized.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/react-native",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
         "@fullstory/babel-plugin-annotate-react": "~2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/react-native",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "The official FullStory React Native plugin",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release-only version bump in the diff; documented changes are targeted crash and compatibility fixes for session readiness callbacks.
> 
> **Overview**
> **Release 1.10.2** bumps `@fullstory/react-native` from **1.10.1** to **1.10.2** and documents two stability fixes in the changelog.
> 
> On **Android (New Architecture)**, session-ready callbacks are guarded so they no longer run against a destroyed TurboModule after the React host shuts down.
> 
> On **Android and iOS**, session events now use **`DeviceEventEmitter`** instead of the TurboModule event emitter, which restores **`onReady`** on the Old Architecture and fixes issues on **32-bit** devices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2473e5317eab5b44fa12f9fda706b399e3ecff8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->